### PR TITLE
Added new dialog action

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,21 +21,22 @@ Quick example:
 ```bash
 npm install attractivejs
 
-# Using importmap-rails
+# using importmap-rails
 ./bin/importmap pin attractivejs
 ```
 
 ```javascript
 import Attractive from "attractivejs"
 
-// Default usage
+// default usage (document as root)
 Attractive.activate();
 
-// With custom element
+// with custom element
 const element = document.getElementById("main");
 
 Attractive.activate({ element: element });
 
+// only with selected actions
 Attractive.activate({ element: element }).withActions(["class"]);
 ```
 
@@ -44,16 +45,16 @@ Attractive.activate({ element: element }).withActions(["class"]);
 
 ```html
 <script defer src="https://cdn.jsdelivr.net/npm/attractivejs@1.x.x/dist/cdn.min.js"></script>
-
 <script>
   document.addEventListener("DOMContentLoaded", () => {
-    // Default usage (document as root)
+    // default usage (document as root)
     Attractive.activate();
 
-    // Or with a custom element
+    // with custom element
     const element = document.querySelector("#main");
-
     Attractive.activate({ element: element });
+
+    // only with selected actions
     Attractive.activate({ element: element }).withActions(["class"]);
   });
 </script>
@@ -62,7 +63,7 @@ Attractive.activate({ element: element }).withActions(["class"]);
 
 ## Usage
 
-Attractive.js works by setting a `data-action` to an element, typically a button or a-element, and, optionally, a `data-target` attribute. The syntax for the `data-action` attribute is `action#value`, `data-target` accepts an `#id` or `.class`.
+Attractive.js works by setting a `data-action` to an element, typically a button or a-element, and, optionally, a `data-target` attribute (it defaults to the direct parent of the element with the `data-action`). The syntax for the `data-action` attribute is `action#value`, `data-target` accepts an `#id`, `.class` or `[attribute="selector"]`.
 
 
 ### Classes
@@ -86,7 +87,19 @@ Attractive.js works by setting a `data-action` to an element, typically a button
 - `toggleDataAttribute`
 
 
+### Dialog
+
+- `dialog#open`
+- `dialog#openModal`
+- `dialog#close`
+
 _More actions coming. See open issues._
+
+
+## Development/test
+
+Run `npm run test`.
+
 
 ## Release
 

--- a/src/actions/dialog.js
+++ b/src/actions/dialog.js
@@ -1,0 +1,35 @@
+import ActionBase from "./base";
+
+class Dialog extends ActionBase {
+  constructor(currentElement, options = {}) {
+    super(currentElement, options);
+  }
+
+  open() {
+    this.#targets.forEach(target => target instanceof HTMLDialogElement && target.show());
+  }
+
+  openModal() {
+    this.#targets.forEach(target => target instanceof HTMLDialogElement && target.showModal());
+  }
+
+  close() {
+    this.#targets.forEach(target => target instanceof HTMLDialogElement && target.close());
+  }
+
+  // private
+
+  get #targets() {
+    return this.targetElement ? Array.from(document.querySelectorAll(this.targetElement)) : Array.from(document.querySelectorAll("dialog"));
+  }
+}
+
+const action = (method) => (element, options = {}) => {
+  new Dialog(element, options)[method]();
+};
+
+export default {
+  open: action("open"),
+  openModal: action("openModal"),
+  close: action("close"),
+};

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,11 +1,13 @@
 import classActions from "./class";
 import attributeActions from "./attribute";
-import DataAttributeActions from "./data_attribute";
+import dataAttributeActions from "./data_attribute";
+import dialogActions from "./dialog";
 
 export const actions = {
   class: classActions,
   attribute: attributeActions,
-  DataAttribute: DataAttributeActions
+  dataAttribute: dataAttributeActions,
+  dialog: dialogActions
 };
 
 export const availableActions = (groups = []) => {

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -39,13 +39,18 @@ class Events {
   #execute(action, { on: element }) {
     Debug.log("Execute action", action, "on", element, "…");
 
-    const [actionName, value = null] = action.includes("#") ? action.split("#") : [action];
+    const parts = action.split("#");
+    const [possibleAction, fallbackAction, fallbackValue] = parts;
 
-    if (!this.#actions[actionName] || typeof this.#actions[actionName] !== "function") return;
+    const actionName = this.#actions[possibleAction] ? possibleAction : (fallbackAction ?? action);
+    const value = this.#actions[possibleAction] ? parts.slice(1).join("#") : (fallbackValue ?? null);
 
-    const targetElement = element.dataset.target;
+    if (typeof this.#actions[actionName] !== "function") return;
 
-    this.#actions[actionName](element, { value: value, targetElement: targetElement });
+    this.#actions[actionName](element, {
+      value,
+      targetElement: element.dataset.target
+    });
 
     Debug.log("…", "executed action", action, "on", element);
   }

--- a/src/debug.js
+++ b/src/debug.js
@@ -1,6 +1,6 @@
 export default class Debug {
   static enabled = false;
-  static prefix = "[🧲]";
+  static prefix = "🧲 ";
 
   static log(...args) {
     if (this.enabled) console.log(this.prefix, ...args)

--- a/test/dialog.html
+++ b/test/dialog.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Attractive.js - Dialog Tests</title>
+  <link rel="stylesheet" href="./styles.css">
+  <script src="../dist/attractive.js"></script>
+</head>
+<body>
+  <h1>Dialog Functionality Tests</h1>
+  <p><a href="index.html">← Back to test index</a></p>
+
+  <div class="test-section">
+    <h2>Dialog Actions with explicit target</h2>
+
+    <button data-action="dialog#open" data-target="#dialog">
+      Open Dialog (show)
+    </button>
+
+    <button data-action="dialog#openModal" data-target="#dialog">
+      Open Dialog (showModal)
+    </button>
+
+    <dialog id="dialog">
+      <h2>Modal Heading</h2>
+      <p>This is a dialog. You can close it with the buttons below.</p>
+
+      <button data-action="dialog#close">Cancel</button>
+
+      <form method="dialog">
+        <button type="submit">Submit</button> (should close via form method; e.g. page redirect or similar
+      </form>
+    </dialog>
+  </div>
+
+  <div class="test-section">
+    <h2>Dialog Actions with implicat target (any `dialog` element)</h2>
+
+    <button data-action="dialog#open">
+      Open Dialog (show)
+    </button>
+
+    <button data-action="dialog#openModal">
+      Open Dialog (showModal)
+    </button>
+  </div>
+</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -12,6 +12,7 @@
     <li><a href="class.html">Class Tests</a></li>
     <li><a href="attribute.html">Attribute Tests</a></li>
     <li><a href="data_attribute.html">Data Attribute Tests</a></li>
+    <li><a href="dialog.html">Dialog Tests</a></li>
     <li><a href="stimulus.html">Stimulus Tests</a></li>
   </ul>
 </body>


### PR DESCRIPTION
Closes: https://github.com/Rails-Designer/attractive.js/issues/1

Usage:

- `dialog#open`
- `dialog#openModal`
- `dialog#close`

```
    <button data-action="dialog#open" data-target="#dialog">
      Open Dialog (show)
    </button>

    <button data-action="dialog#openModal" data-target="#dialog">
      Open Dialog (showModal)
    </button>

    <dialog id="dialog">
      <h2>Modal Heading</h2>
      <p>This is a dialog. You can close it with the buttons below.</p>

      <button data-action="dialog#close">Cancel</button>

      <form method="dialog">
        <button type="submit">Submit</button> (should close via form method; e.g. page redirect or similar
      </form>
    </dialog>
```