### PR TITLE
Make self/currentElement the default implicit target

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ A light-weight library for declarative DOM actions using data attributes.
 
 Quick example:
 ```html
-<p>
+<p id="content">
   This element should toggle the `active` class when clicking the button below.
 
-  <button data-action="toggleClass#active">
+  <button data-action="toggleClass#active" data-target="#content">
     Toggle
   </button>
 </p>
@@ -73,39 +73,34 @@ Including above script-tag is enough to get started. Configure Attractive.js if 
 
 ## Usage
 
-Attractive.js works by setting a `data-action` attribute to an element, typically a button or a-element, and, optionally, a `data-target` attribute (it defaults to the direct parent of the element with the `data-action` for most actions). The syntax for the `data-action` attribute is, most commonly, `action#value`, `data-target` accepts an `#id`, `.class` or `[attribute="selector"]` (anything that can be passed to `querySelectorAll()`.
+Attractive.js works by setting a `data-action` attribute to an element, typically a button or a-element, and, optionally, a `data-target` attribute (by default, the action applies to the element itself). The syntax for the `data-action` attribute is, most commonly, `action#value`, `data-target` accepts an `#id`, `.class` or `[attribute="selector"]` (anything that can be passed to `querySelectorAll()`).
 
 
 ### Examples
 
-Without a `data-target` attribute, the direct parent of the element with `data-action` is implicitly set.
 ```html
-<p>
+<p id="content">
   This element should have the `active` class toggled when clicking the button below.
 
-  <button data-action="toggleClass#active">
+  <button data-action="toggleClass#active" data-target="#content">
     Toggle
   </button>
 </p>
 ```
 
-With an explicit target.
+Without an explicit target.
 ```html
-<p id="target">
-  This element should have the `active` class toggled when clicking the button below.
-</p>
-
-<button data-action="toggleClass#active" data-target="#target">
-  Toggle
+<button data-action="toggleClass#active">
+  Toggle (this button should have the `active` class toggled)
 </button>
 ```
 
 Defining multiple classes.
 ```html
-<p>
+<p id="content">
   This element should have the `bg-red-100` and `border-red-300` classes toggled when clicking the button below.
 
-  <button data-action="toggleClass#bg-red-100,border-red-300">
+  <button data-action="toggleClass#bg-red-100,border-red-300" data-target="#content">
     Toggle
   </button>
 </p>
@@ -203,7 +198,7 @@ Define a debounce (delay) for the submit action with `data-submit-delay="n"` (`n
 Define a feedback duration with `data-copy-duration="n"` (`n` is in ms).
 
 - `copy#string`
-- `copy` (assumes a `data-target` to be copyable)
+- `copy` (no value; assumes a `data-target` to be copyable)
 
 
 ### ScrollTo

--- a/src/actions/base.js
+++ b/src/actions/base.js
@@ -8,6 +8,6 @@ export default class ActionBase {
   }
 
   get targets() {
-    return this.targetElement ? Array.from(document.querySelectorAll(this.targetElement)) : [this.currentElement.parentElement];
+    return this.targetElement ? Array.from(document.querySelectorAll(this.targetElement)) : [this.currentElement];
   }
 }

--- a/src/actions/scroll_to.js
+++ b/src/actions/scroll_to.js
@@ -11,11 +11,7 @@ class ScrollTo extends ActionBase {
   }
 
   scroll() {
-    if (this.currentElement.hasAttribute("data-target")) {
-      this.targets[0]?.scrollIntoView({ behavior: this.behavior });
-    } else {
-      this.currentElement.scrollIntoView({ behavior: this.behavior });
-    }
+    this.targets[0]?.scrollIntoView({ behavior: this.behavior });
   }
 }
 

--- a/src/debug.js
+++ b/src/debug.js
@@ -1,5 +1,5 @@
 export default class Debug {
-  static enabled = true; // ⚠️ TODO: revert
+  static enabled = false;
   static prefix = "🧲 ";
 
   static log(...args) {

--- a/test/attribute.html
+++ b/test/attribute.html
@@ -6,11 +6,11 @@
   <script src="../dist/attractive.js"></script>
 </head>
 <body>
-  <h1>Attribute Functionality Tests</h1>
+  <h1>Attribute</h1>
   <p><a href="index.html">← Back to test index</a></p>
 
   <div class="test-section">
-    <h2>Toggle Disabled Attribute with Explicit Target</h2>
+    <h2>Toggle disabled attribute with explicit target</h2>
 
     <button data-action="toggleAttribute#disabled=disabled" data-target="#name">
       Toggle disabled State
@@ -30,12 +30,8 @@
   <div class="test-section">
     <h2>Add Hidden on Parent (Default Target)</h2>
 
-    <div>
-      <button data-action="addAttribute#hidden">
-        Toggle Parent Visibility
-      </button>
-
-      <p>The parent div should toggle visibility when the button is clicked.</p>
+    <div data-action="addAttribute#hidden">
+      The parent div should toggle visibility when this element is clicked.
     </div>
   </div>
 

--- a/test/class.html
+++ b/test/class.html
@@ -6,14 +6,14 @@
   <script src="../dist/attractive.js"></script>
 </head>
 <body>
-  <h1>Class Functionality Tests</h1>
+  <h1>Class</h1>
   <p><a href="index.html">← Back to test index</a></p>
 
   <div class="test-section">
-    <h2>Toggle Class with Explicit Target</h2>
+    <h2>Toggle class with explicit target</h2>
 
     <button data-action="toggleClass#active" data-target="#target">
-      Toggle Active Class
+      Toggle
     </button>
 
     <p id="target" class="target">
@@ -22,10 +22,10 @@
   </div>
 
   <div class="test-section">
-    <h2>Toggle Classes with Explicit Target</h2>
+    <h2>Toggle classes with explicit target</h2>
 
     <button data-action="toggleClass#,active,zoomIn," data-target="#container">
-      Toggle Active Classes
+      Toggle
     </button>
 
     <p id="container" class="target">
@@ -34,23 +34,15 @@
   </div>
 
   <div class="test-section">
-    <h2>Toggle Class on Parent (Default Target)</h2>
+    <h2>Add/remove class by hovering over element below</h2>
 
-    <div class="target">
-      <button data-action="addClass#highlight">
-        Add Highlight on Parent
-      </button>
-
-      <button data-action="removeClass#highlight">
-        Remove Highlight on Parent
-      </button>
-
-      <p>The parent div should add and remove the `highlight` class when each respective button is clicked.</p>
+    <div class="target" data-action="mouseover->addClass#highlight mouseout->removeClass#highlight">
+      <p>This div should add and remove the `highlight` class upon hover (useful! 🦉).</p>
     </div>
   </div>
 
   <div class="test-section">
-    <h2>Attractive.js with Multiple Events</h2>
+    <h2>Attractive.js with multiple events</h2>
 
     <button data-action="click->toggleClass#active,zoomIn mouseover->addClass#highlight mouseout->removeClass#highlight" data-target="#multi-event-target">
       Hover and Click Me

--- a/test/clipboard.html
+++ b/test/clipboard.html
@@ -21,7 +21,7 @@
   <script src="../dist/attractive.js"></script>
 </head>
 <body>
-  <h1>Clipboard Functionality Tests</h1>
+  <h1>Clipboard</h1>
   <p><a href="index.html">← Back to test index</a></p>
 
   <div class="test-section">
@@ -44,7 +44,7 @@
   <div class="test-section">
     <h2>Copy from code (5s custom duration)</h2>
 
-    <p>Your access code is: <code id="access-code">abc-123-def-456</code></p>
+    <p>Your access code is: <code id="access-code">ghi-789-jkl-012</code></p>
     <button data-action="copy" data-target="#access-code" data-copy-duration="5000">
       Copy (highlight on success)
     </button>

--- a/test/data_attribute.html
+++ b/test/data_attribute.html
@@ -6,21 +6,23 @@
   <script src="../dist/attractive.js"></script>
 </head>
 <body>
-  <h1>Data Attribute Functionality Tests</h1>
+  <h1>Data Attribute</h1>
   <p><a href="index.html">← Back to test index</a></p>
 
   <div class="test-section">
-    <h2>Product Grid Sorting</h2>
+    <h2>Product grid sorting</h2>
 
     <div class="filter-buttons">
       <button data-action="addDataAttribute#sort=price" data-target="#product-grid">
-        Sort by Price
+        Sort by price
       </button>
+
       <button data-action="addDataAttribute#sort=date" data-target="#product-grid">
-        Sort by Date
+        Sort by date
       </button>
+
       <button data-action="removeDataAttribute#sort" data-target="#product-grid">
-        Clear Sort
+        Clear sort
       </button>
     </div>
 
@@ -33,15 +35,15 @@
     <h2>Collapsible Panel</h2>
 
     <button data-action="toggleDataAttribute#expanded" data-target="#panel">
-      Toggle Expand Panel
+      Toggle expand panel
     </button>
 
     <button data-action="addDataAttribute#expanded" data-target="#panel">
-      Add Expand Panel
+      Add expand panel
     </button>
 
     <button data-action="removeDataAttribute#expanded" data-target="#panel">
-      Remove Expand Panel
+      Remove expand panel
     </button>
 
     <div id="panel" class="panel">
@@ -50,17 +52,16 @@
   </div>
 
   <div class="test-section">
-    <h2>Loading States</h2>
+    <h2>Loading states</h2>
 
     <div class="card" id="content">
-      <h3>Dynamic Content</h3>
+      <h3>Dynamic content</h3>
+
       <p>Content that can be reloaded</p>
     </div>
 
-    <button
-      data-action="toggleDataAttribute#loading=lazy"
-      data-target="#content">
-      Reload Content
+    <button data-action="toggleDataAttribute#loading=lazy" data-target="#content">
+      Reload content
     </button>
   </div>
 </body>

--- a/test/dialog.html
+++ b/test/dialog.html
@@ -6,41 +6,42 @@
   <script src="../dist/attractive.js"></script>
 </head>
 <body>
-  <h1>Dialog Functionality Tests</h1>
+  <h1>Dialog</h1>
   <p><a href="index.html">← Back to test index</a></p>
 
   <div class="test-section">
-    <h2>Dialog Actions with explicit target</h2>
+    <h2>Dialog actions with explicit target</h2>
 
     <button data-action="dialog#open" data-target="#dialog">
-      Open Dialog (show)
+      Open dialog (show)
     </button>
 
     <button data-action="dialog#openModal" data-target="#dialog">
-      Open Dialog (showModal)
+      Open dialog (showModal)
     </button>
 
     <dialog id="dialog">
       <h2>Modal Heading</h2>
       <p>This is a dialog. You can close it with the buttons below.</p>
 
-      <button data-action="dialog#close">Cancel</button>
 
       <form method="dialog">
+        <button type="button" data-action="dialog#close" data-target="#dialog">Cancel</button>
+
         <button type="submit">Submit</button> (should close via form method; e.g. page redirect or similar
       </form>
     </dialog>
   </div>
 
   <div class="test-section">
-    <h2>Dialog Actions with implicit target (any `dialog` element)</h2>
+    <h2>Dialog actions with implicit target (any `dialog` element)</h2>
 
     <button data-action="dialog#open">
-      Open Dialog (show)
+      Open dialog (show)
     </button>
 
     <button data-action="dialog#openModal">
-      Open Dialog (showModal)
+      Open dialog (showModal)
     </button>
   </div>
 </body>

--- a/test/form.html
+++ b/test/form.html
@@ -29,9 +29,9 @@
   <div class="test-section">
     <h2>With implicit targets</h2>
 
-    <form method="get" action="#">
+    <form id="preferences" method="get" action="#">
       <label for="framework">Framework (submits form on select)</label>
-      <select id="framework" name="framework" data-action="form#submit">
+      <select id="framework" name="framework" data-action="form#submit" data-target="#preferences">
         <option value="">Choose your JS library</option>
         <option value="attractive">attractive.js</option>
         <option value="turbo">turbo</option>
@@ -43,9 +43,9 @@
   <div class="test-section">
     <h2>With implicit targets, and debounce/delay</h2>
 
-    <form method="get" action="#">
+    <form id="more-preferences" method="get" action="#">
       <label for="framework">Framework (submits form on select, after a delay)</label>
-      <select id="framework" name="framework" data-action="form#submit" data-submit-delay="1000">
+      <select id="framework" name="framework" data-action="form#submit" data-target="#more-preferences" data-submit-delay="1000">
         <option value="">Choose your JS library</option>
         <option value="attractive">attractive.js</option>
         <option value="turbo">turbo</option>

--- a/test/index.html
+++ b/test/index.html
@@ -1,18 +1,17 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Attractive.js Test</title>
+  <title>Attractive.js test</title>
   <link rel="stylesheet" href="./styles.css">
 </head>
 <body>
-  <h1>Attractive.js Test Suite</h1>
-  <p>Select a test to run:</p>
+  <h1>Attractive.js test suite</h1>
 
   <ul class="test-links">
-    <li><a href="class.html">Class Tests</a></li>
-    <li><a href="attribute.html">Attribute Tests</a></li>
-    <li><a href="data_attribute.html">Data Attribute Tests</a></li>
-    <li><a href="dialog.html">Dialog Tests</a></li>
+    <li><a href="class.html">Class</a></li>
+    <li><a href="attribute.html">Attribute</a></li>
+    <li><a href="data_attribute.html">Data Attribute</a></li>
+    <li><a href="dialog.html">Dialog</a></li>
     <li><a href="form.html">Form</a></li>
     <li><a href="clipboard.html">Clipboard</a></li>
     <li><a href="scroll_to.html">ScrollTo</a></li>

--- a/test/intersection.html
+++ b/test/intersection.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Attractive.js - Intersection Tests</title>
+  <title>Attractive.js - Intersection tests</title>
   <link rel="stylesheet" href="./styles.css">
   <style>
     .spacer {
@@ -43,7 +43,7 @@
     .content {
       padding: 2rem;
       border: 2px solid #ccc;
-      transition: background-color 300ms, border-color 300ms;
+      transition: background-color 300ms 800ms, border-color 300ms 800ms;
 
       &.playing {
         background-color: #e6fffa;
@@ -65,7 +65,7 @@
 <body>
   <header id="header">Sticky header</header>
 
-  <h1>Intersection Functionality Tests</h1>
+  <h1>Intersection</h1>
   <p><a href="index.html">← Back to test index</a></p>
 
   <div class="spacer">↓ Scroll down ↓</div>
@@ -73,7 +73,7 @@
   <div class="test-section">
     <h2>Add Class once on self (`intersect-once`)</h2>
 
-    <div id="reveal-box" class="reveal-box" data-action="intersect-once#animate-fade-in" data-target="#reveal-box">
+    <div class="reveal-box" data-action="intersect-once#animate-fade-in">
       This box should fade in once and stay visible.
     </div>
   </div>
@@ -92,8 +92,8 @@
   <div class="test-section">
     <h2>Toggle multiple classes on self (`intersect-toggle`)</h2>
 
-    <div id="content" class="content" data-action="intersect-toggle#playing,focus" data-target="content">
-      This player's state should toggle as it enters/leaves the viewport.
+    <div class="content" data-action="intersect-toggle#playing,focus">
+      This element should toggle as it enters/leaves the viewport.
     </div>
   </div>
 

--- a/test/scroll_to.html
+++ b/test/scroll_to.html
@@ -6,9 +6,9 @@
   <style>
     .scroll-container {
       height: 200px;
-      overflow-y: scroll;
-      border: 1px solid #ccc;
       padding: 1rem;
+      border: 1px solid #ccc;
+      overflow-y: scroll;
 
       & li,
       & div {
@@ -23,7 +23,7 @@
   <script src="../dist/attractive.js"></script>
 </head>
 <body>
-  <h1>ScrollTo Functionality Tests</h1>
+  <h1>ScrollTo</h1>
   <p><a href="index.html">← Back to test index</a></p>
 
   <div class="test-section">

--- a/test/stimulus.html
+++ b/test/stimulus.html
@@ -3,10 +3,8 @@
 <head>
   <title>Attractive.js with Stimulus</title>
   <link rel="stylesheet" href="./styles.css">
-  <!-- Load Stimulus properly -->
   <script src="https://unpkg.com/@hotwired/stimulus@3.2.2/dist/stimulus.umd.js"></script>
   <script>
-    // Initialize Stimulus
     (function() {
       const application = Stimulus.Application.start();
 
@@ -22,25 +20,26 @@
       console.log("Stimulus initialized");
     })();
   </script>
-  <!-- Load Attractive.js after Stimulus -->
   <script src="../dist/attractive.js"></script>
 </head>
 <body>
-  <h1>Attractive.js and Stimulus Compatibility Test</h1>
+  <h1>Attractive.js and Stimulus test</h1>
   <p><a href="index.html">← Back to test index</a></p>
 
   <div class="test-section">
-    <h2>Attractive.js Action</h2>
+    <h2>Attractive.js action</h2>
+
     <button data-action="toggleClass#active" data-target="#attractive-target">
       Toggle with Attractive.js
     </button>
+
     <div id="attractive-target" class="target">
       This element is controlled by Attractive.js
     </div>
   </div>
 
   <div class="test-section">
-    <h2>Stimulus Controller</h2>
+    <h2>Stimulus controller</h2>
 
     <div data-controller="toggle">
       <button data-action="click->toggle#toggle">
@@ -54,10 +53,10 @@
   </div>
 
   <div class="test-section">
-    <h2>Attractive.js with Event Prefix</h2>
+    <h2>Attractive.js with event prefix</h2>
 
     <button data-action="click->toggleClass#active" data-target="#prefixed-target">
-      Toggle with Event Prefix
+      Toggle
     </button>
 
     <div id="prefixed-target" class="target">
@@ -66,7 +65,7 @@
   </div>
 
   <div class="test-section">
-    <h2>Mixed Usage (with data-controller)</h2>
+    <h2>Mixed usage (with data-controller)</h2>
 
     <div data-controller="toggle">
       <button data-action="click->toggle#toggle toggleClass#active" data-target="#mixed-target">


### PR DESCRIPTION
This change makes way more sense than the previous direct parentElement. I think setting a `data-target` should be the default, but in some cases the implicit target to self can clean up the code a fair bit.

In general currentElement as the implicit target is just way more obvious.