### PR TITLE
Add support for space-separated values

### DIFF
--- a/src/core/events.js
+++ b/src/core/events.js
@@ -12,13 +12,29 @@ class Events {
   process(event, { on: element, using: defaultEventType }) {
     if (!element) return;
 
-    const action = element.dataset.action;
-    const actions = action.split(" ");
+    const actions = this.#splitActions(element.dataset.action);
 
     actions.forEach(action => this.#evaluate(action, { for: event, on: element, using: defaultEventType }));
   }
 
   // private
+
+  #splitActions(action) {
+    const result = [];
+    let currentAction = '';
+    let inBackticks = false;
+
+    [...action].forEach(character => {
+      if (character === "`") return inBackticks = !inBackticks;
+      if (character === " " && !inBackticks) return currentAction && (result.push(currentAction), currentAction = "");
+
+      currentAction += character;
+    });
+
+    if (currentAction) result.push(currentAction);
+
+    return result;
+  }
 
   #evaluate(action, { for: event, on: element, using: defaultEventType }) {
     Debug.log("Process action for", event.type, "on", element, "…");

--- a/test/clipboard.html
+++ b/test/clipboard.html
@@ -33,6 +33,14 @@
   </div>
 
   <div class="test-section">
+    <h2>Copy inline space-delimited value</h2>
+
+    <button data-action="copy#`copy me maybe?`">
+      Copy me maybe?
+    </button>
+  </div>
+
+  <div class="test-section">
     <h2>Copy from input</h2>
 
     <input type="text" id="share-link" value="https://railsdesigner.com/articles/" readonly>


### PR DESCRIPTION
Add support for space delimited values (mostly useful for clipboard action); by wrapping the value in backticks (`).

```html
<button data-action="copy#`copy me maybe?`">
  Copy me maybe?
</button>
```