### PR TITLE
Keep data-copy-success={true,false} attribute on clipboard by default

### DIFF
--- a/src/actions/clipboard.js
+++ b/src/actions/clipboard.js
@@ -6,9 +6,6 @@ class Clipboard extends ActionBase {
     super(currentElement, options);
 
     this.value = options.value;
-
-    const duration = currentElement.dataset.copyDuration;
-    this.duration = duration ? parseInt(duration) : 2000;
   }
 
   async copy() {
@@ -28,11 +25,13 @@ class Clipboard extends ActionBase {
   // private
 
   #setFeedback(succeeded) {
-    const attributeValue = String(succeeded);
+    const duration = this.currentElement.dataset.copyDuration;
 
-    this.targets.forEach(target => target.setAttribute(this.#attributeName, attributeValue));
+    this.targets.forEach(target => target.setAttribute(this.#attributeName, succeeded));
 
-    debounce(() => this.targets.forEach(target => target.removeAttribute(this.#attributeName)), this.duration);
+    if (!duration) return;
+
+    debounce(() => this.targets.forEach(target => target.removeAttribute(this.#attributeName)), parseInt(duration));
   }
 
   get #attributeName() {

--- a/test/clipboard.html
+++ b/test/clipboard.html
@@ -50,10 +50,10 @@
   </div>
 
   <div class="test-section">
-    <h2>Copy from code (5s custom duration)</h2>
+    <h2>Copy from code (highlight for 2s)</h2>
 
     <p>Your access code is: <code id="access-code">ghi-789-jkl-012</code></p>
-    <button data-action="copy" data-target="#access-code" data-copy-duration="5000">
+    <button data-action="copy" data-target="#access-code" data-copy-duration="2000">
       Copy (highlight on success)
     </button>
   </div>


### PR DESCRIPTION
Set `data-copy-duration="n"` to remove the attribute after `n` ms.