### PR TITLE
Add window/document event targeting

### DIFF
--- a/src/core/events.js
+++ b/src/core/events.js
@@ -60,7 +60,8 @@ class Events {
     Debug.log("Process action for", event.type, "on", element, "…");
 
     if (action.includes("->")) {
-      const [eventName, actionPart] = action.split("->");
+      const [eventPart, actionPart] = action.split("->");
+      const eventName = eventPart.includes("@") ? eventPart.split("@")[1] : eventPart;
 
       if (eventName !== event.type) return;
 

--- a/test/class.html
+++ b/test/class.html
@@ -82,7 +82,7 @@
     </div>
 
     <div class="test-section">
-      <h2>Attractive.js with multiple events</h2>
+      <h2>With multiple events</h2>
 
       <button
         data-action="click->toggleClass#active,zoomIn mouseover->addClass#highlight mouseout->removeClass#highlight"
@@ -94,6 +94,18 @@
       <div id="multi-event-target" class="target">
         This element responds to multiple events
       </div>
+    </div>
+
+    <div class="test-section" data-action="window@resize->addClass#active">
+      <h2>Added on self on window resize</h2>
+    </div>
+
+    <div class="test-section" data-action="window@resize->addClass#active" data-target="#resizedTarget">
+      <h2>Added on defined target on window resize</h2>
+
+      <p id="resizedTarget" class="target">
+        This element should add the `active` class on window resize.
+      </p>
     </div>
   </body>
 </html>


### PR DESCRIPTION
This should close https://github.com/Rails-Designer/attractivejs/issues/33

Enables listening to window and document events using Stimulus-inspired `@` syntax. Examples:

- `document@turbo:load->addClass#loading`
- `window@resize->toggleClass#mobile`
- `document@DOMContentLoaded->removeClass#hidden`

Instead of adding more logic or syntactic sugar, this window/document event targeting should be enough. 

The only “syntactic sugar” I am contemplating is a `:action` syntax, e.g. instead of `document@DOMContentLoaded->removeClass#hidden` → `removeClass#hidden:now` which might/will be part of some predefined action-types (e.g. `removeAttribute#open:whenOutside`.