### PR TITLE
Add action modifiers for conditional execution

### DIFF
--- a/src/actions/element.js
+++ b/src/actions/element.js
@@ -1,5 +1,4 @@
 import ActionBase from "./base";
-import debounce from "./../helpers/debounce";
 
 class Element extends ActionBase {
   add() {
@@ -26,7 +25,7 @@ class Element extends ActionBase {
     };
 
     if (delay) {
-      debounce(removeElements, delay);
+      setTimeout(removeElements, delay);
     } else {
       removeElements();
     }

--- a/src/attractive.js
+++ b/src/attractive.js
@@ -1,6 +1,7 @@
 import Events from "./core/events";
 import EventTypes from "./core/event_types";
 import Observer from "./core/observer";
+import Modifiers from "./core/modifiers";
 import actions, { availableActions } from "./actions";
 import Debug from "./debug";
 
@@ -80,6 +81,18 @@ class Attractive {
         const targetObject = target === "window" ? window : document;
 
         this.#addTargetedEventListener(eventType, targetObject, element);
+      });
+
+    const modifiers = actions
+      .filter(action => action.includes(":"))
+      .map(action => action.split(":")[1]);
+
+      modifiers.forEach(modifier => {
+        Modifiers.setup({
+          for: modifier,
+          on: element,
+          trigger: () => this.#events.process({ type: modifier }, { on: element, using: modifier })
+        });
       });
   }
 

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -32,7 +32,13 @@ class Events {
   #evaluate(action, { for: event, on: element, using: defaultEventType }) {
     Debug.log("Process action for", event.type, "on", element, "…");
 
-    if (action.includes("->")) {
+    if (action.includes(":")) {
+      const [actionPart, modifier] = action.split(":");
+
+      if (event.type !== modifier) return;
+
+      action = actionPart;
+    } else if (action.includes("->")) {
       const [eventPart, actionPart] = action.split("->");
       const eventName = eventPart.includes("@") ? eventPart.split("@")[1] : eventPart;
 

--- a/src/core/modifiers.js
+++ b/src/core/modifiers.js
@@ -1,0 +1,37 @@
+class Modifiers {
+  #modifiers = {
+    mounted: (_, trigger) => {
+      trigger();
+    },
+
+    now: (_, trigger) => {
+      trigger();
+    },
+
+    whenVisible: (element, trigger) => {
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            trigger();
+
+            observer.disconnect();
+          }
+        });
+      });
+
+      observer.observe(element);
+    },
+  };
+
+  setup({ for: modifier, on: element, trigger }) {
+    const setup = this.#modifiers[modifier];
+
+    if (!setup) return false;
+
+    setup(element, trigger);
+
+    return true;
+  }
+}
+
+export default new Modifiers();


### PR DESCRIPTION
Enables modifiers using colon syntax to control when actions execute (inspired by Stimulus):

- `element#remove:mounted`: remove element when added to DOM ("aliased" to `now`)
- `addClass#animateBounce:whenVisible`: add class when element enters viewport

`mounted`/`now` is useful for elements that are programmatically added to the dom, like flash messages via Turbo Streams

I like the simple `whenVisible` for IntersectionObserver stuff. Would be good to extend the intersect action to be more versatile or just remove it?