### PR TITLE
Set attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "attractivejs",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "attractivejs",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^16.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -173,7 +173,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -214,7 +213,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1456,7 +1454,6 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2427,7 +2424,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2631,7 +2627,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -2699,7 +2694,6 @@
       "integrity": "sha512-6TyDmZ1HXoFQXnhCTUjVFULReoBPOAjpuiKELMkeP40yffI/1ZRO+d9ug/VC6fqISo2WkuIBk3cvuRPALaWlOQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "builtins": "^5.0.1",
@@ -2742,7 +2736,6 @@
       "integrity": "sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -4087,7 +4080,6 @@
       "integrity": "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^6.7.2",
         "cssstyle": "^5.3.1",
@@ -5118,7 +5110,6 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attractivejs",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "A light-weight library for declarative DOM actions using data attributes",
   "scripts": {
     "build": "rollup -c",

--- a/src/actions/attribute.js
+++ b/src/actions/attribute.js
@@ -34,6 +34,14 @@ class Attribute extends ActionBase {
     );
   }
 
+  set() {
+    if (!this.attribute) return;
+
+    this.targets.forEach((target) => {
+      target.setAttribute(this.attribute, this.value || "");
+    });
+  }
+
   remove() {
     if (!this.attribute) return;
 
@@ -64,5 +72,6 @@ export default {
   toggleAttribute: action("toggle"),
   cycleAttribute: action("cycle"),
   addAttribute: action("add"),
+  setAttribute: action("set"),
   removeAttribute: action("remove")
 };

--- a/src/actions/class.js
+++ b/src/actions/class.js
@@ -26,6 +26,15 @@ class Class extends ActionBase {
     this.targets.forEach((target) => target.classList.add(...this.value));
   }
 
+  set() {
+    if (!this.value) return;
+
+    this.targets.forEach((target) => {
+      target.className = "";
+      target.classList.add(...this.value);
+    });
+  }
+
   remove() {
     if (!this.value) return;
 
@@ -61,5 +70,6 @@ export default {
   toggleClass: action("toggle"),
   cycleClass: action("cycle"),
   addClass: action("add"),
+  setClass: action("set"),
   removeClass: action("remove")
 };

--- a/src/actions/data_attribute.js
+++ b/src/actions/data_attribute.js
@@ -34,6 +34,14 @@ class DataAttribute extends ActionBase {
     });
   }
 
+  set() {
+    if (!this.attribute) return;
+
+    this.targets.forEach((target) => {
+      target.dataset[this.attribute] = this.value || "";
+    });
+  }
+
   remove() {
     if (!this.attribute) return;
 
@@ -64,5 +72,6 @@ export default {
   toggleDataAttribute: action("toggle"),
   cycleDataAttribute: action("cycle"),
   addDataAttribute: action("add"),
+  setDataAttribute: action("set"),
   removeDataAttribute: action("remove")
 };

--- a/tests/actions/attribute.test.js
+++ b/tests/actions/attribute.test.js
@@ -49,6 +49,20 @@ describe('Attribute Actions', () => {
     });
   });
 
+  describe('setAttribute', () => {
+    test('setAttribute sets attribute with value', () => {
+      attributeActions.setAttribute(element, { value: 'data-state=active', target: 'target' });
+
+      expect(element.getAttribute('data-state')).toBe('active');
+    });
+
+    test('setAttribute sets attribute without value', () => {
+      attributeActions.setAttribute(element, { value: 'hidden', target: 'target' });
+
+      expect(element.getAttribute('hidden')).toBe('');
+    });
+  });
+
   describe('removeAttribute', () => {
     test('removes existing attribute', () => {
       attributeActions.removeAttribute(element, { value: 'data-existing', target: 'target' });

--- a/tests/actions/class.test.js
+++ b/tests/actions/class.test.js
@@ -28,6 +28,18 @@ describe('Class Actions', () => {
     expect([...element.classList]).toEqual(['existing', 'active', 'visible']);
   });
 
+  test('setClass sets multiple classes', () => {
+    classActions.setClass(element, { value: 'active,visible', target: "target" });
+
+    expect([...element.classList]).toEqual(['active', 'visible']);
+  });
+
+  test('setClass sets single class', () => {
+    classActions.setClass(element, { value: 'primary', target: "target" });
+
+    expect([...element.classList]).toEqual(['primary']);
+  });
+
   test('removeClass removes specified classes', () => {
     classActions.removeClass(element, { value: 'existing', target: "target" });
 

--- a/tests/actions/data_attribute.test.js
+++ b/tests/actions/data_attribute.test.js
@@ -33,6 +33,19 @@ describe('DataAttribute Actions', () => {
     expect(element.dataset.flag).toBe('');
   });
 
+  test('setDataAttribute sets data attribute with value', () => {
+    dataAttributeActions.setDataAttribute(element, { value: 'status=active', target: "target" });
+
+    expect(element.dataset.status).toBe('active');
+  });
+
+  test('setDataAttribute sets empty data attribute when no value', () => {
+    dataAttributeActions.setDataAttribute(element, { value: 'flag', target: "target" });
+
+    expect(element.dataset.flag).toBe('');
+  });
+
+
   test('removeDataAttribute removes specified data attribute', () => {
     dataAttributeActions.removeDataAttribute(element, { value: 'existing', target: "target" });
 

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -76,25 +76,4 @@ describe('Integration', () => {
     const target = document.getElementById('target');
     expect(target.classList.contains('fallback')).toBe(true);
   });
-
-  // test('activation on specific element only observes that subtree', async () => {
-  //   document.body.innerHTML = `
-  //     <div id="outside" data-action="addClass#outside:mounted" data-target="result">Outside</div>
-
-  //     <div id="container">
-  //       <div data-action="addClass#inside:mounted" data-target="result">Inside container</div>
-  //     </div>
-
-  //     <div id="result">Target</div>
-  //   `;
-
-  //   // Only observe the container element
-  //   const container = document.getElementById('container');
-  //   Attractive.activate({ on: container });
-  //   await vi.runAllTimersAsync();
-
-  //   const result = document.getElementById('result');
-  //   expect(result.classList.contains('outside')).toBe(false); // Not observed
-  //   expect(result.classList.contains('inside')).toBe(true);   // Observed
-  // });
 });


### PR DESCRIPTION
Add set method to class, attribute and data-attribute actions

Adds a `set` method to some classes that completely replaces existing values rather than adding to them.

- `data-action="setClass#bg-red-500`
- `data-action="setAttribute#hidden`
- `data-action="setDataAttribute#controller=reload`