### PR TITLE
Add richer context to actions

### DIFF
--- a/src/core/action_controller.js
+++ b/src/core/action_controller.js
@@ -132,7 +132,7 @@ class ActionController {
         trigger: () =>
           this.#events.process(
             { type: modifier },
-            { on: element, using: defaultEventType }
+            { on: element, using: defaultEventType, triggeredBy: modifier }
           )
       });
     });

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -12,7 +12,10 @@ class Events {
     this.#hooks = hooks;
   }
 
-  async process(event, { on: element, using: defaultEventType }) {
+  async process(
+    event,
+    { on: element, using: defaultEventType, triggeredBy: modifier }
+  ) {
     if (!element) return;
 
     const actionValue = this.#getActionValue(element);
@@ -23,7 +26,8 @@ class Events {
       const result = await this.#evaluate(action, {
         for: event,
         on: element,
-        using: defaultEventType
+        using: defaultEventType,
+        triggeredBy: modifier
       });
 
       if (result === false) return false;
@@ -80,7 +84,7 @@ class Events {
 
   async #evaluate(
     action,
-    { for: event, on: element, using: defaultEventType }
+    { for: event, on: element, using: defaultEventType, triggeredBy: modifier }
   ) {
     let hasCustomEvent = false;
 
@@ -118,10 +122,14 @@ class Events {
       return;
     }
 
-    return await this.#execute(action, { on: element, for: event });
+    return await this.#execute(action, {
+      on: element,
+      for: event,
+      triggeredBy: modifier
+    });
   }
 
-  async #execute(action, { on: element, for: event }) {
+  async #execute(action, { on: element, for: event, triggeredBy: modifier }) {
     const parts = action.split("#");
     const [possibleAction, fallbackAction, fallbackValue] = parts;
     const actionName = this.#registry.hasAction(possibleAction)
@@ -151,6 +159,19 @@ class Events {
       event: event || null
     };
 
+    const actionContext = {
+      value,
+      target: this.#getTargetValue(element),
+      targets: this.#getTargetsValue(element),
+      event: event || null,
+      actionName,
+      triggeredBy: modifier || null,
+      dataset: element.dataset,
+      dispatchEvent: (name, detail = {}) => {
+        element.dispatchEvent(new CustomEvent(name, { detail, bubbles: true }));
+      }
+    };
+
     if (this.#hooks) {
       if (this.#hooks.runBefore(context) === false) {
         if (event) event.preventDefault();
@@ -164,11 +185,7 @@ class Events {
     let result;
 
     try {
-      result = await actionFunction(element, {
-        value,
-        target: this.#getTargetValue(element),
-        targets: this.#getTargetsValue(element)
-      });
+      result = await actionFunction(element, actionContext);
     } catch (error) {
       const targetId = element.id || this.#getTargetValue(element) || "";
 

--- a/tests/core/context.test.js
+++ b/tests/core/context.test.js
@@ -1,0 +1,105 @@
+import { describe, test, expect } from "vitest";
+import Events from "../../src/core/events.js";
+import Registry from "../../src/core/registry.js";
+
+function setup() {
+  const registry = new Registry();
+  let captured = null;
+
+  registry.registerAction("testAction", function (element, context) {
+    captured = context;
+  });
+
+  const events = new Events(registry, "on", null);
+
+  return { events, getContext: () => captured };
+}
+
+describe("Action context", () => {
+  test("passes event to action function", () => {
+    const { events, getContext } = setup();
+    const button = document.createElement("button");
+
+    button.setAttribute("on", "testAction");
+
+    events.process(new MouseEvent("click"), { on: button, using: "click" });
+
+    expect(getContext()).toBeDefined();
+    expect(getContext().event).toBeInstanceOf(MouseEvent);
+  });
+
+  test("includes dataset", () => {
+    const { events, getContext } = setup();
+    const button = document.createElement("button");
+
+    button.setAttribute("on", "testAction");
+    button.setAttribute("data-role", "admin");
+
+    events.process(new MouseEvent("click"), { on: button, using: "click" });
+
+    expect(getContext().dataset.role).toBe("admin");
+  });
+
+  test("includes dispatchEvent helper", () => {
+    const { events, getContext } = setup();
+    const button = document.createElement("button");
+
+    button.setAttribute("on", "testAction");
+
+    events.process(new MouseEvent("click"), { on: button, using: "click" });
+
+    expect(typeof getContext().dispatchEvent).toBe("function");
+  });
+
+  test("dispatchEvent dispatches a CustomEvent", () => {
+    const { events, getContext } = setup();
+    const button = document.createElement("button");
+
+    button.setAttribute("on", "testAction");
+
+    let capturedDetail;
+
+    button.addEventListener("app-event", (event) => {
+      capturedDetail = event.detail;
+    });
+
+    events.process(new MouseEvent("click"), { on: button, using: "click" });
+
+    getContext().dispatchEvent("app-event", { key: "value" });
+
+    expect(capturedDetail).toEqual({ key: "value" });
+  });
+
+  test("triggeredBy is null for direct events", () => {
+    const { events, getContext } = setup();
+    const button = document.createElement("button");
+
+    button.setAttribute("on", "testAction");
+
+    events.process(new MouseEvent("click"), { on: button, using: "click" });
+
+    expect(getContext().triggeredBy).toBeNull();
+  });
+
+  test("old-style destructuring of value still works", () => {
+    const { events, getContext } = setup();
+    const button = document.createElement("button");
+
+    button.setAttribute("on", "testAction#hello");
+
+    events.process(new MouseEvent("click"), { on: button, using: "click" });
+
+    expect(getContext().value).toBe("hello");
+  });
+
+  test("includes actionName", () => {
+    const { events, getContext } = setup();
+    const button = document.createElement("button");
+
+    button.setAttribute("on", "testAction");
+
+    events.process(new MouseEvent("click"), { on: button, using: "click" });
+
+    expect(getContext().actionName).toBe("testAction");
+  });
+});

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -401,4 +401,98 @@ describe("Integration", () => {
     const target = document.getElementById("target");
     expect(target.classList.contains("loaded")).toBe(true);
   });
+
+  test("action context includes event for event-triggered actions", async () => {
+    let receivedEvent;
+
+    app.registerAction("captureEvent", (element, { event }) => {
+      receivedEvent = event;
+    });
+
+    app.activate();
+
+    document.body.innerHTML = `
+      <button id="btn" data-action="captureEvent">Click</button>
+    `;
+
+    await vi.runAllTimersAsync();
+
+    document.getElementById("btn").click();
+
+    await vi.runAllTimersAsync();
+
+    expect(receivedEvent).toBeInstanceOf(MouseEvent);
+    expect(receivedEvent.type).toBe("click");
+  });
+
+  test("action context includes dataset", async () => {
+    let receivedDataset;
+
+    app.registerAction("captureDataset", (element, { dataset }) => {
+      receivedDataset = dataset;
+    });
+
+    app.activate();
+
+    document.body.innerHTML = `
+      <button id="btn" data-action="captureDataset" data-custom="hello">Click</button>
+    `;
+
+    await vi.runAllTimersAsync();
+
+    document.getElementById("btn").click();
+
+    await vi.runAllTimersAsync();
+
+    expect(receivedDataset.custom).toBe("hello");
+  });
+
+  test("dispatchEvent helper dispatches a CustomEvent", async () => {
+    let capturedEvent;
+
+    app.registerAction("dispatchTest", (element, { dispatchEvent }) => {
+      element.addEventListener("test-event", (event) => {
+        capturedEvent = event;
+      });
+
+      dispatchEvent("test-event", { key: "value" });
+    });
+
+    app.activate();
+
+    document.body.innerHTML = `
+      <button id="btn" data-action="dispatchTest">Click</button>
+    `;
+
+    await vi.runAllTimersAsync();
+
+    document.getElementById("btn").click();
+
+    await vi.runAllTimersAsync();
+
+    expect(capturedEvent).toBeInstanceOf(CustomEvent);
+    expect(capturedEvent.detail).toEqual({ key: "value" });
+  });
+
+  test("old-style handler destructuring still works", async () => {
+    let receivedValue = null;
+
+    app.registerAction("oldStyle", (element, { value }) => {
+      receivedValue = value;
+    });
+
+    app.activate();
+
+    document.body.innerHTML = `
+      <button id="btn" data-action="oldStyle#hello">Click</button>
+    `;
+
+    await vi.runAllTimersAsync();
+
+    document.getElementById("btn").click();
+
+    await vi.runAllTimersAsync();
+
+    expect(receivedValue).toBe("hello");
+  });
 });


### PR DESCRIPTION
Previously:
```js
app.registerAction("myAction", (element, { value, target, targets }) => {
  // Only value, target, targets available
})
```

No actions receive the full context: value, target, targets, event, dataset, etc

Closes: https://github.com/Rails-Designer/attractivejs/issues/56