### PR TITLE
Added global onError

### DIFF
--- a/src/attractive.js
+++ b/src/attractive.js
@@ -58,10 +58,23 @@ class Attractive {
     return Debug.enabled;
   }
 
+  static onError(error, message, detail) {
+    console.warn(`[attractive] ${message}`, error);
+
+    if (typeof window.onerror === "function") {
+      window.onerror(message, null, null, null, error);
+    }
+  }
+
   constructor(options = {}) {
     this.#prefix = options.prefix || defaultPrefix;
 
-    this.#events = new Events(this.#registry, this.#prefix, this.#hooks);
+    this.#events = new Events(
+      this.#registry,
+      this.#prefix,
+      this.#hooks,
+      (error, message, detail) => Attractive.onError(error, message, detail)
+    );
     this.#eventTypes = new EventTypes(this.#registry);
     this.#modifiers = new Modifiers(this.#registry);
     this.#listeners = new EventListeners((event, context) =>

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -5,11 +5,13 @@ class Events {
   #registry;
   #prefix;
   #hooks;
+  #onError;
 
-  constructor(registry, prefix, hooks) {
+  constructor(registry, prefix, hooks, onError) {
     this.#registry = registry;
     this.#prefix = prefix;
     this.#hooks = hooks;
+    this.#onError = onError;
   }
 
   async process(
@@ -188,16 +190,17 @@ class Events {
       result = await actionFunction(element, actionContext);
     } catch (error) {
       const targetId = element.id || this.#getTargetValue(element) || "";
+      const message = `${actionName} on ${element.tagName.toLowerCase()}#${targetId}: ${error.message}`;
 
-      Debug.error(
-        `${actionName} on ${element.tagName.toLowerCase()}#${targetId}: ${error.message}`
-      );
+      Debug.error(message);
 
       if (this.#hooks) {
         this.#hooks.runError({ ...context, error });
       }
 
-      throw error;
+      if (this.#onError) {
+        this.#onError(error, message, { actionName, element });
+      }
     }
 
     if (this.#hooks) {

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -484,6 +484,77 @@ describe("Integration", () => {
     expect(capturedEvent.detail).toEqual({ key: "value" });
   });
 
+  test("error from action does not bubble up as unhandled", async () => {
+    app.registerAction("thrower", () => {
+      throw new Error("boom");
+    });
+
+    app.activate();
+
+    document.body.innerHTML = `
+      <button id="btn" on="thrower">Click</button>
+    `;
+
+    await vi.runAllTimersAsync();
+
+    expect(() => {
+      document.getElementById("btn").click();
+    }).not.toThrow();
+  });
+
+  test("instance onError hook fires when action throws", async () => {
+    const hook = vi.fn();
+    const error = new Error("boom");
+
+    app.registerAction("thrower", () => {
+      throw error;
+    });
+
+    app.onError(hook);
+    app.activate();
+
+    document.body.innerHTML = `
+      <button id="btn" on="thrower">Click</button>
+    `;
+
+    await vi.runAllTimersAsync();
+    document.getElementById("btn").click();
+    await vi.runAllTimersAsync();
+
+    expect(hook).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "thrower", error })
+    );
+  });
+
+  test("Attractive.onError global handler receives error context", async () => {
+    const handler = vi.fn();
+    const original = Attractive.onError;
+
+    Attractive.onError = handler;
+
+    app.registerAction("thrower", () => {
+      throw new Error("boom");
+    });
+
+    app.activate();
+
+    document.body.innerHTML = `
+      <button id="btn" on="thrower">Click</button>
+    `;
+
+    await vi.runAllTimersAsync();
+    document.getElementById("btn").click();
+    await vi.runAllTimersAsync();
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.stringContaining("thrower"),
+      expect.objectContaining({ actionName: "thrower" })
+    );
+
+    Attractive.onError = original;
+  });
+
   test("old-style handler destructuring still works", async () => {
     let receivedValue = null;
 


### PR DESCRIPTION
Useful for error monitoring:
```
Attractive.onError = (error, message, detail) => {
  // eg. Sentry.captureException(error, { extra: detail });
};
```