### PR TITLE
Export action as default and rename `plugin`

### DIFF
--- a/src/actions/attribute.js
+++ b/src/actions/attribute.js
@@ -4,5 +4,6 @@ export {
   addAttribute,
   setAttribute,
   removeAttribute,
+  attributeAction,
   default
 } from "./dom_attributes.js";

--- a/src/actions/class.js
+++ b/src/actions/class.js
@@ -49,8 +49,7 @@ class Class extends ActionBase {
 
   #cycleClasses(target) {
     const currentClass =
-      this.value.find((className) => target.classList.contains(className)) ||
-      "";
+      this.value.find((className) => target.classList.contains(className)) || "";
     const nextClass = this.cycledValue(currentClass, this.value);
 
     target.classList.remove(...this.value);
@@ -58,7 +57,7 @@ class Class extends ActionBase {
   }
 }
 
-export const action =
+const activate =
   (method) =>
   (element, options = {}) => {
     const instance = new Class(element, options);
@@ -66,17 +65,17 @@ export const action =
     return instance[method]();
   };
 
-export const toggleClass = action("toggle");
-export const cycleClass = action("cycle");
-export const addClass = action("add");
-export const setClass = action("set");
-export const removeClass = action("remove");
+export const toggleClass = activate("toggle");
+export const cycleClass = activate("cycle");
+export const addClass = activate("add");
+export const setClass = activate("set");
+export const removeClass = activate("remove");
 
 const actions = { toggleClass, cycleClass, addClass, setClass, removeClass };
 
 export default actions;
 
-export const plugin = {
+export const classAction = {
   name: "class",
   actions
 };

--- a/src/actions/clipboard.js
+++ b/src/actions/clipboard.js
@@ -48,7 +48,7 @@ class Clipboard extends ActionBase {
   }
 }
 
-export const action =
+const activate =
   (method) =>
   (element, options = {}) => {
     const instance = new Clipboard(element, options);
@@ -56,13 +56,13 @@ export const action =
     return instance[method]();
   };
 
-export const copy = action("copy");
+export const copy = activate("copy");
 
 const actions = { copy };
 
 export default actions;
 
-export const plugin = {
+export const clipboardAction = {
   name: "clipboard",
   actions
 };

--- a/src/actions/confirm.js
+++ b/src/actions/confirm.js
@@ -26,18 +26,18 @@ class Confirm extends ActionBase {
   }
 }
 
-export const action =
+const activate =
   (method) =>
   (element, options = {}) =>
     new Confirm(element, options)[method]();
 
-export const confirm = action("confirm");
+export const confirm = activate("confirm");
 
 const actions = { confirm };
 
 export default actions;
 
-export const plugin = {
+export const confirmAction = {
   name: "confirm",
   actions
 };

--- a/src/actions/data_attribute.js
+++ b/src/actions/data_attribute.js
@@ -7,5 +7,6 @@ export {
   cycleDataAttribute,
   addDataAttribute,
   setDataAttribute,
-  removeDataAttribute
+  removeDataAttribute,
+  dataAttributeAction
 } from "./dom_attributes.js";

--- a/src/actions/dialog.js
+++ b/src/actions/dialog.js
@@ -20,21 +20,21 @@ class Dialog extends ActionBase {
   }
 }
 
-const action =
+const activate =
   (method) =>
   (element, options = {}) => {
     new Dialog(element, options)[method]();
   };
 
-export const open = action("open");
-export const openModal = action("openModal");
-export const close = action("close");
+export const open = activate("open");
+export const openModal = activate("openModal");
+export const close = activate("close");
 
 const actions = { open, openModal, close };
 
 export default actions;
 
-export const plugin = {
+export const dialogAction = {
   name: "dialog",
   actions
 };

--- a/src/actions/dom_attributes.js
+++ b/src/actions/dom_attributes.js
@@ -108,7 +108,7 @@ class DataAttribute extends ActionBase {
   }
 }
 
-const action =
+const activate =
   (method, ClassType) =>
   (element, options = {}) => {
     const instance = new ClassType(element, options);
@@ -116,17 +116,17 @@ const action =
     return instance[method]();
   };
 
-export const toggleAttribute = action("toggle", Attribute);
-export const cycleAttribute = action("cycle", Attribute);
-export const addAttribute = action("add", Attribute);
-export const setAttribute = action("set", Attribute);
-export const removeAttribute = action("remove", Attribute);
+export const toggleAttribute = activate("toggle", Attribute);
+export const cycleAttribute = activate("cycle", Attribute);
+export const addAttribute = activate("add", Attribute);
+export const setAttribute = activate("set", Attribute);
+export const removeAttribute = activate("remove", Attribute);
 
-export const toggleDataAttribute = action("toggle", DataAttribute);
-export const cycleDataAttribute = action("cycle", DataAttribute);
-export const addDataAttribute = action("add", DataAttribute);
-export const setDataAttribute = action("set", DataAttribute);
-export const removeDataAttribute = action("remove", DataAttribute);
+export const toggleDataAttribute = activate("toggle", DataAttribute);
+export const cycleDataAttribute = activate("cycle", DataAttribute);
+export const addDataAttribute = activate("add", DataAttribute);
+export const setDataAttribute = activate("set", DataAttribute);
+export const removeDataAttribute = activate("remove", DataAttribute);
 
 const attributeActions = {
   toggleAttribute,
@@ -148,12 +148,12 @@ export { dataAttributeActions };
 
 export default attributeActions;
 
-export const plugin = {
+export const attributeAction = {
   name: "attribute",
   actions: attributeActions
 };
 
-export const dataPlugin = {
+export const dataAttributeAction = {
   name: "dataAttribute",
   actions: dataAttributeActions
 };

--- a/src/actions/element.js
+++ b/src/actions/element.js
@@ -40,7 +40,7 @@ class Element extends ActionBase {
   }
 }
 
-export const action =
+const activate =
   (method) =>
   (element, options = {}) => {
     const instance = new Element(element, options);
@@ -48,14 +48,14 @@ export const action =
     return instance[method]();
   };
 
-export const add = action("add");
-export const remove = action("remove");
+export const add = activate("add");
+export const remove = activate("remove");
 
 const actions = { add, remove };
 
 export default actions;
 
-export const plugin = {
+export const elementAction = {
   name: "element",
   actions
 };

--- a/src/actions/focus.js
+++ b/src/actions/focus.js
@@ -10,18 +10,18 @@ class Focus extends ActionBase {
   }
 }
 
-export const action =
+const activate =
   (method) =>
   (element, options = {}) =>
     new Focus(element, options)[method]();
 
-export const focus = action("focus");
+export const focus = activate("focus");
 
 const actions = { focus };
 
 export default actions;
 
-export const plugin = {
+export const focusAction = {
   name: "focus",
   actions
 };

--- a/src/actions/form.js
+++ b/src/actions/form.js
@@ -24,20 +24,20 @@ class Form extends ActionBase {
   }
 }
 
-const action =
+const activate =
   (method) =>
   (element, options = {}) => {
     new Form(element, options)[method]();
   };
 
-export const submit = action("requestSubmit");
-export const reset = action("reset");
+export const submit = activate("requestSubmit");
+export const reset = activate("reset");
 
 const actions = { submit, reset };
 
 export default actions;
 
-export const plugin = {
+export const formAction = {
   name: "form",
   actions
 };

--- a/src/actions/reload.js
+++ b/src/actions/reload.js
@@ -16,7 +16,7 @@ class Reload extends ActionBase {
   }
 }
 
-export const action =
+const activate =
   (method) =>
   (element, options = {}) => {
     const instance = new Reload(element, options);
@@ -24,13 +24,13 @@ export const action =
     return instance[method]();
   };
 
-export const reload = action("reload");
+export const reload = activate("reload");
 
 const actions = { reload, refresh: reload };
 
 export default actions;
 
-export const plugin = {
+export const reloadAction = {
   name: "reload",
   actions
 };

--- a/src/actions/request.js
+++ b/src/actions/request.js
@@ -215,7 +215,7 @@ class Request extends ActionBase {
   }
 }
 
-export const action =
+const activate =
   (method) =>
   (element, options = {}) => {
     const instance = new Request(element, options);
@@ -223,16 +223,16 @@ export const action =
     return instance[method]();
   };
 
-export const get = action("get");
-export const post = action("post");
-export const patch = action("patch");
-export const put = action("put");
+export const get = activate("get");
+export const post = activate("post");
+export const patch = activate("patch");
+export const put = activate("put");
 
 const actions = { get, post, patch, put };
 
 export default actions;
 
-export const plugin = {
+export const requestAction = {
   name: "request",
   actions
 };

--- a/src/actions/scroll_to.js
+++ b/src/actions/scroll_to.js
@@ -15,20 +15,20 @@ class ScrollTo extends ActionBase {
   }
 }
 
-export const action =
+const activate =
   (method) =>
   (element, options = {}) => {
     const instance = new ScrollTo(element, options);
     return instance[method]();
   };
 
-export const scrollTo = action("scroll");
+export const scrollTo = activate("scroll");
 
 const actions = { scrollTo };
 
 export default actions;
 
-export const plugin = {
+export const scrollToAction = {
   name: "scrollTo",
   actions
 };

--- a/src/attractive.js
+++ b/src/attractive.js
@@ -168,37 +168,43 @@ class Attractive {
   }
 
   /**
-   * Registers a plugin that provides actions, modifiers, or event types.
+   * Registers actions, modifiers, or event types from an extension object.
    *
-   * @param {Object} plugin
-   * @param {string} plugin.name — plugin identifier
-   * @param {Object<string, Function>} [plugin.actions] — action name to handler map
-   * @param {Object<string, Function>} [plugin.modifiers] — modifier name to setup/gate function map
-   * @param {Object<string, string>} [plugin.eventTypeOverrides] — tag name to event type map
-   * @param {Function} [plugin.init] — called after registration with the instance
+   * @param {Object|Object[]} action
+   * @param {string} action.name — action identifier
+   * @param {Object<string, Function>} [action.actions] — action name to handler map
+   * @param {Object<string, Function>} [action.modifiers] — modifier name to setup/gate function map
+   * @param {Object<string, string>} [action.eventTypeOverrides] — tag name to event type map
+   * @param {Function} [action.init] — called after registration with the instance
    * @returns {Attractive} — the instance for chaining
    */
-  use(plugin) {
-    if (plugin.actions) {
-      Object.entries(plugin.actions).forEach(([name, action]) =>
+  use(action) {
+    if (Array.isArray(action)) {
+      action.forEach((item) => this.use(item));
+
+      return this;
+    }
+
+    if (action.actions) {
+      Object.entries(action.actions).forEach(([name, action]) =>
         this.#registry.registerAction(name, action)
       );
     }
 
-    if (plugin.modifiers) {
-      Object.entries(plugin.modifiers).forEach(([name, setup]) =>
+    if (action.modifiers) {
+      Object.entries(action.modifiers).forEach(([name, setup]) =>
         this.#registry.registerModifier(name, setup)
       );
     }
 
-    if (plugin.eventTypeOverrides) {
-      Object.entries(plugin.eventTypeOverrides).forEach(([tag, event]) =>
+    if (action.eventTypeOverrides) {
+      Object.entries(action.eventTypeOverrides).forEach(([tag, event]) =>
         this.#registry.registerEventTypeOverride(tag, event)
       );
     }
 
-    if (plugin.init) {
-      plugin.init(this);
+    if (action.init) {
+      action.init(this);
     }
 
     return this;

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -1,7 +1,10 @@
 import { describe, test, expect, beforeEach, vi } from "vitest";
 import Attractive from "../src/index.js";
+import CoreAttractive from "../src/attractive.js";
 import builtinActions from "../src/actions/index.js";
 import { defaultModifiers } from "../src/core/modifier_definitions.js";
+import { classAction } from "../src/actions/class.js";
+import { elementAction } from "../src/actions/element.js";
 
 globalThis.Node = globalThis.Node || { ELEMENT_NODE: 1 };
 
@@ -575,5 +578,99 @@ describe("Integration", () => {
     await vi.runAllTimersAsync();
 
     expect(receivedValue).toBe("hello");
+  });
+});
+
+describe("Core build with selective actions", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    vi.clearAllTimers();
+    vi.useFakeTimers();
+  });
+
+  test("use action registers all actions from a bundle", async () => {
+    const app = new CoreAttractive();
+    app.use(classAction);
+    app.registerModifiers((registry) => {
+      defaultModifiers(registry);
+    });
+    app.activate();
+
+    document.body.innerHTML = `
+      <button id="btn" on="addClass#active" on-target="target">
+        <span id="target">Target</span>
+      </button>
+    `;
+
+    await vi.runAllTimersAsync();
+
+    document.getElementById("btn").click();
+
+    const target = document.getElementById("target");
+    expect(target.classList.contains("active")).toBe(true);
+  });
+
+  test("use action registers multiple bundles", async () => {
+    const app = new CoreAttractive();
+    app.use(classAction);
+    app.use(elementAction);
+    app.registerModifiers((registry) => {
+      defaultModifiers(registry);
+    });
+    app.activate();
+
+    document.body.innerHTML = `
+      <div id="container">
+        <div id="target">Remove me</div>
+      </div>
+      <button id="btn" on="remove" on-target="target">Remove</button>
+    `;
+
+    await vi.runAllTimersAsync();
+
+    document.getElementById("btn").click();
+
+    expect(document.getElementById("target")).toBeNull();
+  });
+
+  test("use accepts an array of action bundles", async () => {
+    const app = new CoreAttractive();
+    app.use([classAction, elementAction]);
+    app.registerModifiers((registry) => {
+      defaultModifiers(registry);
+    });
+    app.activate();
+
+    document.body.innerHTML = `
+      <button id="btn" on="addClass#active" on-target="target">
+        <span id="target">Target</span>
+      </button>
+    `;
+
+    await vi.runAllTimersAsync();
+
+    document.getElementById("btn").click();
+
+    const target = document.getElementById("target");
+    expect(target.classList.contains("active")).toBe(true);
+  });
+
+  test("unregistered actions are not available", async () => {
+    const app = new CoreAttractive();
+    app.use(classAction);
+    app.registerModifiers((registry) => {
+      defaultModifiers(registry);
+    });
+    app.activate();
+
+    document.body.innerHTML = `
+      <button id="btn" on="copy">Copy</button>
+    `;
+
+    await vi.runAllTimersAsync();
+
+    expect(() => {
+      document.getElementById("btn").click();
+    }).not.toThrow();
   });
 });


### PR DESCRIPTION
With this usage with core is now:
```
import Attractive from "../dist/attractive.core.js";
import { classAction } from "../dist/actions/class.js";
import { clipboardAction } from "../dist/actions/clipboard.js";

const attractive = new Attractive();
attractive.use(classAction).use(clipboardAction);
# or `attractive.use([classAction, clipboardAction]);`
attractive.activate();
```