### PR TITLE
Add option to activate from script tag

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,4 +24,16 @@ if (typeof window !== "undefined") {
   window.Attractive = Attractive;
 }
 
+if (
+  typeof document !== "undefined" &&
+  (
+    document.currentScript ??
+    document.querySelector('script[src*="attractive"][activate]')
+  )?.hasAttribute("activate")
+) {
+  document.readyState === "loading"
+    ? document.addEventListener("DOMContentLoaded", () => Attractive.activate())
+    : Attractive.activate();
+}
+
 export default Attractive;


### PR DESCRIPTION
This allows to use Attractive.js directly without activation like so:
```html
<script src="unpkg.com/attractivejs" type="module" activate></script>
```

Instead of:
```html
<script type="module">
   import Attractive from "unpkg.com/attractivejs";

   Attractive.activate({ debug: true });
</script>
```