### PR TITLE
Add keyboard extension

### DIFF
--- a/docs/app/content/articles/keyboard.md
+++ b/docs/app/content/articles/keyboard.md
@@ -1,0 +1,139 @@
+---
+title: Keyboard
+description: Filter keydown events with dot modifiers like .enter, .escape and combo syntax ctrl+k
+category: extensions
+position: 1
+---
+
+Keyboard adds key-filter dot modifiers for `@keydown` and global `@hotkey` shortcuts.
+
+## Usage
+
+```js
+import Attractive from "attractivejs";
+import { keyboard } from "attractivejs/keyboard";
+
+Attractive.extend(keyboard);
+
+const attractive = Attractive.activate();
+```
+
+Or per-instance:
+
+```js
+const attractive = Attractive.activate();
+attractive.extend(keyboard);
+```
+
+## @keydown vs @hotkey
+
+| Directive    | Scope    |
+| ------------ | -------- |
+| `@keydown.*` | Element — must be focused |
+| `@hotkey.*`  | Global — suppressed when editing form fields |
+
+## @keydown
+
+Dot modifiers filter which keys trigger the action. The element must be focused for `@keydown` to fire:
+
+```html
+<input @keydown.enter="addClass#submitted" @target="status" />
+```
+
+Children of the focused element also trigger it, since events bubble:
+
+```html
+<form @keydown.enter="addClass#searching" @target="results">
+  <input name="q" />
+  <button>Search</button>
+</form>
+```
+
+| Modifier      | Checks                        |
+| ------------- | ----------------------------- |
+| `.enter`      | `event.key === "Enter"`       |
+| `.escape`     | `event.key === "Escape"`      |
+| `.space`      | `event.key === " "`           |
+| `.tab`        | `event.key === "Tab"`         |
+| `.arrowup`    | `event.key === "ArrowUp"`     |
+| `.arrowdown`  | `event.key === "ArrowDown"`   |
+| `.arrowleft`  | `event.key === "ArrowLeft"`   |
+| `.arrowright` | `event.key === "ArrowRight"`  |
+| `.ctrl`       | `event.ctrlKey`               |
+| `.alt`        | `event.altKey`                |
+| `.shift`      | `event.shiftKey`              |
+| `.meta`       | `event.metaKey` (Cmd on Mac)  |
+| `.window`     | Listens on `window` instead   |
+| `.document`   | Listens on `document` instead |
+
+A bare `@keydown` fires on any key:
+
+```html
+<input @keydown="addClass#pressed" @target="status" />
+```
+
+Multiple keys combine with `+`:
+
+```html
+<input @keydown.ctrl+k="focus" @target="search-field" />
+<input @keydown.shift+enter="addClass#submitted" @target="status" />
+```
+
+### Global with `.window`
+
+Add `.window` to fire globally regardless of element focus. Editable elements (input, textarea, select, contenteditable) suppress the action when focused:
+
+```html
+<div @keydown.meta+s.window="addClass#saved" @target="status">Save</div>
+<div @keydown.escape.window="removeAttribute#open" @target="menu">Close</div>
+```
+
+## @hotkey
+
+`@hotkey` fires globally, no `.window` required. It handles focus isolation automatically.
+
+
+### Bare hotkey
+
+Without a value, `@hotkey` calls `element.click()`:
+```html
+<a href="/inbox" @hotkey.g.i>Inbox (g then i)</button>
+<button @hotkey.escape @action="removeAttribute#open" @target="menu">Close</button>
+```
+
+### Valued hotkey
+
+With a value, `@hotkey` dispatches a synthetic `hotkey` event through the action pipeline:
+```html
+<button @hotkey.escape="removeAttribute#open" @target="menu">Close</button>
+<button @hotkey.ctrl+k="focus" @target="search">Search</button>
+```
+
+### Hotkey syntax
+
+`@hotkey` supports three forms:
+
+| Form       | Example             | Triggers when                          |
+| ---------- | ------------------- | -------------------------------------- |
+| Single key | `@hotkey.escape`    | Escape is pressed                      |
+| Combo (+)  | `@hotkey.ctrl+k`    | `Ctrl` and `K` are held simultaneously     |
+| Sequence   | `@hotkey.g.i`       | `G` is pressed, released, then ``I`` pressed |
+
+- `+` separates keys pressed simultaneously (combo): `@hotkey.ctrl+shift+z`
+- `.` separates sequential steps: `@hotkey.g.i` (g then i)
+
+### Cancellable event
+
+Before the action fires, `@hotkey` dispatches a cancellable `attractive:hotkey` CustomEvent on the element. Call `preventDefault()` to stop the action:
+
+```js
+element.addEventListener("attractive:hotkey", (event) => {
+  if (someCondition) event.preventDefault();
+});
+```
+
+The event `detail` includes the matched key `path` array.
+
+### Focus vs click
+
+Hotkeys on form elements (input, textarea, select, contenteditable) focus the element instead of clicking it.

--- a/docs/app/models/content/article.rb
+++ b/docs/app/models/content/article.rb
@@ -3,6 +3,7 @@ class Content::Article < Perron::Resource
     "get-started" => "Getting started",
     "basics" => "Basics",
     "advanced" => "Advanced",
+    "extensions" => "Extensions"
   }
 
   Category = Data.define(:key, :name, :resources)
@@ -17,7 +18,7 @@ class Content::Article < Perron::Resource
 
   delegate :category, :position, :title, :description, to: :metadata
 
-  adjacent_by :position, within: { category: %w[introduction basics advanced] }
+  adjacent_by :position, within: { category: Content::Article::CATEGORIES.keys }
 
   validates :title, :description, presence: true
   validates :category, inclusion: { in: CATEGORIES.keys }

--- a/package.json
+++ b/package.json
@@ -78,6 +78,9 @@
     },
     "./actions/style": {
       "import": "./dist/actions/style.js"
+    },
+    "./keyboard": {
+      "import": "./dist/keyboard.js"
     }
   },
   "files": [

--- a/playground/index.html
+++ b/playground/index.html
@@ -8,11 +8,58 @@
     />
     <script type="module">
       import Attractive from "../dist/attractive.min.js";
+      import { keyboard } from "../dist/keyboard.js";
 
-      Attractive.activate({ debug: true });
+      const attractive = Attractive.activate({ debug: true });
+      attractive.extend(keyboard);
     </script>
   </head>
   <body>
+    <h2>Keyboard</h2>
+
+    <h3>1. global with dot (@hotkey.escape, bare → click delegation)</h3>
+    <p>
+      <button @hotkey.escape @action="removeClass#active" @target="keyTarget1">
+        Press Escape globally
+      </button>
+      <code id="keyTarget1" class="active">target (class reset)</code>
+    </p>
+
+    <h3>2. global with + (@hotkey.ctrl+k, valued → synthetic hotkey event)</h3>
+    <p>
+      <button @hotkey.ctrl+k="addClass#active" @target="keyTarget2">
+        Press Ctrl+K globally
+      </button>
+      <code id="keyTarget2">target (class added)</code>
+    </p>
+
+    <h3>3. hotkey with dot — sequence (@hotkey.g.i, bare → click)</h3>
+    <p>
+      <a @hotkey.g.i @action="toggleClass#active" @target="keyTarget3" href="#">
+        Inbox (press g then i)
+      </a>
+      <code id="keyTarget3">target (toggled)</code>
+    </p>
+
+    <h3>4. hotkey with + — combo (@hotkey.g+i, valued → synthetic event)</h3>
+    <p>
+      <button @hotkey.g+i="toggleClass#active" @target="keyTarget4">
+        Press g+i simultaneously
+      </button>
+      <code id="keyTarget4">target (toggled)</code>
+    </p>
+
+    <h3>5. keydown on input (@keydown, element-scoped)</h3>
+    <p>
+      <input
+        @keydown.meta+enter="addClass#active"
+        @keydown.escape="removeClass#active"
+        @target="kbTarget"
+        placeholder="Focus here, press Cmd+Enter or Escape"
+      />
+      <code id="kbTarget">target</code>
+    </p>
+
     <h2>Toggle (@="" syntax)</h2>
     <button @action="toggleClass#active" @target="toggleTarget">Toggle</button>
     <p id="toggleTarget">This toggles the <code>active</code> class.</p>

--- a/rolldown.config.js
+++ b/rolldown.config.js
@@ -87,5 +87,22 @@ export default [
     }
   }),
 
+  defineConfig({
+    input: "src/addons/keyboard/index.js",
+    output: {
+      file: "dist/keyboard.js",
+      format: "es"
+    }
+  }),
+
+  defineConfig({
+    input: "src/addons/keyboard/index.js",
+    output: {
+      file: "dist/keyboard.min.js",
+      format: "es",
+      minify: true
+    }
+  }),
+
   ...actionConfigs
 ];

--- a/src/addons/README.md
+++ b/src/addons/README.md
@@ -1,0 +1,41 @@
+# Addons
+
+Addons extend Attractive instances with event modifiers, directives and behaviors. Registered via `instance.extend()` or `Attractive.extend()`.
+
+
+## Usage
+
+```js
+import Attractive from "attractivejs";
+import { keyboard } from "attractivejs/keyboard";
+
+const attractive = Attractive.activate();
+attractive.extend(keyboard);
+```
+
+
+## Available addons
+
+| Addon    | Import                  | Description                                                                |
+| -------- | ----------------------- | -------------------------------------------------------------------------- |
+| keyboard | `attractivejs/keyboard` | Key-filter dot modifiers (.enter, .escape…) and global @hotkey shortcuts |
+
+
+## Writing an addon
+
+An addon is a function receiving `{ instance, registry }`:
+```js
+export function myAddon({ instance, registry }) {
+  registry.addEventModifier("custom", (event, element) => {
+    return event.key === "CustomKey";
+  });
+}
+```
+
+
+### What addons can do
+
+- `registry.addEventModifier(name, handler)`; register a dot modifier (`.custom`) for event directives
+- `instance.onElementAdded(callback)` / `instance.onElementRemoved(callback)`; observe DOM element lifecycle
+- `instance.addEventListener(type, handler)`; register global event listeners on the instance scope
+- `instance.addAction(name, action)`; register a custom action

--- a/src/addons/keyboard/active_editable_element.js
+++ b/src/addons/keyboard/active_editable_element.js
@@ -1,0 +1,28 @@
+export default function activeEditableElement() {
+  return editableElement(document.activeElement);
+}
+
+export function editableElement(element) {
+  if (!element || !element.tagName) return false;
+
+  const tag = element.tagName.toLowerCase();
+
+  if (tag === "textarea" || tag === "select") return true;
+
+  if (tag === "input") {
+    const type = element.type?.toLowerCase();
+
+    return !(
+      type === "button" ||
+      type === "checkbox" ||
+      type === "file" ||
+      type === "hidden" ||
+      type === "image" ||
+      type === "radio" ||
+      type === "reset" ||
+      type === "submit"
+    );
+  }
+
+  return element.isContentEditable;
+}

--- a/src/addons/keyboard/hotkey.js
+++ b/src/addons/keyboard/hotkey.js
@@ -1,0 +1,243 @@
+import activeEditableElement, {
+  editableElement
+} from "./active_editable_element.js";
+import Debug from "./../../debug";
+
+const HOTKEY_PREFIX = "@hotkey.";
+
+class Hotkey {
+  #elements = new Set();
+  #sequenceState = new Map();
+  #modifierKeys = new Set(["ctrl", "alt", "shift", "meta"]);
+  #heldKeys = new Set();
+  #sequenceTimeout = 1500;
+  #listening = false;
+
+  setup(instance) {
+    if (this.#listening) return;
+
+    this.#listening = true;
+
+    instance.onElementAdded((element) => {
+      if (this.#hasHotkeyAttribute(element)) this.#elements.add(element);
+    });
+
+    instance.onElementRemoved((element) => {
+      this.#elements.delete(element);
+    });
+
+    Array.from(document.querySelectorAll("*"))
+      .filter((element) => this.#hasHotkeyAttribute(element))
+      .forEach((element) => this.#elements.add(element));
+
+    document.addEventListener("keyup", (event) => {
+      this.#heldKeys.delete(event.key);
+    });
+
+    instance.addEventListener("keydown", (event) => {
+      this.#heldKeys.add(event.key);
+
+      if (!activeEditableElement()) {
+        this.#process(event);
+      }
+    });
+  }
+
+  clearSequenceState() {
+    this.#sequenceState.forEach((step) => clearTimeout(step.timeout));
+    this.#sequenceState.clear();
+  }
+
+  // private
+
+  #hasHotkeyAttribute(element) {
+    return Array.from(element.attributes).some((attribute) =>
+      attribute.name.startsWith(HOTKEY_PREFIX)
+    );
+  }
+
+  #process(event) {
+    let activated = false;
+
+    for (const element of this.#elements) {
+      if (this.#processElement({ for: event, on: element })) {
+        activated = true;
+      }
+    }
+
+    if (activated) {
+      event.preventDefault();
+      this.#heldKeys.clear();
+    }
+  }
+
+  #processElement({ for: event, on: element }) {
+    const hotkey = this.#hotkeyAttribute({ for: element });
+    if (!hotkey) return false;
+
+    const { modifiers, value } = hotkey;
+    const combo = modifiers.some((part) => part.includes("+"));
+
+    if (combo) {
+      const keys = modifiers.flatMap((part) => part.split("+"));
+      const systemKeys = keys.filter((key) => this.#modifierKeys.has(key));
+      const triggerKeys = keys.filter((key) => !this.#modifierKeys.has(key));
+
+      if (this.#matches({ for: event }, { systemKeys, triggerKeys })) {
+        Debug.log("hotkey combo →", element);
+        this.#activate({ on: element, with: value, path: modifiers });
+
+        return true;
+      }
+
+      return false;
+    }
+
+    if (modifiers.length > 1) {
+      return this.#matchSequence({
+        for: event,
+        on: element,
+        sequence: modifiers,
+        with: value
+      });
+    }
+
+    if (event.key.toLowerCase() === modifiers[0].toLowerCase()) {
+      this.#activate({ on: element, with: value, path: modifiers });
+
+      return true;
+    }
+
+    return false;
+  }
+
+  #hotkeyAttribute({ for: element }) {
+    const attribute = Array.from(element.attributes).find((attribute) =>
+      attribute.name.startsWith(HOTKEY_PREFIX)
+    );
+
+    if (!attribute) return null;
+
+    return {
+      modifiers: attribute.name.slice(HOTKEY_PREFIX.length).split("."),
+      value: attribute.value
+    };
+  }
+
+  #matchSequence({ for: event, on: element, sequence, with: value }) {
+    const step = this.#sequenceState.get(element);
+    const expected = step ? sequence[step.position] : sequence[0];
+
+    if (event.key.toLowerCase() !== expected) {
+      this.#resetSequence({ on: element });
+
+      return false;
+    }
+
+    if (!step) {
+      this.#startSequence({ on: element, sequence });
+
+      return false;
+    }
+
+    if (this.#heldKeys.has(sequence[step.position - 1])) {
+      this.#resetSequence({ on: element });
+
+      return false;
+    }
+
+    return this.#advanceSequence({
+      for: event,
+      on: element,
+      step,
+      sequence,
+      with: value
+    });
+  }
+
+  #matches({ for: event }, { systemKeys, triggerKeys }) {
+    if (systemKeys.includes("ctrl") && !event.ctrlKey) return false;
+    if (systemKeys.includes("alt") && !event.altKey) return false;
+    if (systemKeys.includes("shift") && !event.shiftKey) return false;
+    if (systemKeys.includes("meta") && !event.metaKey) return false;
+    if (triggerKeys.some((key) => !this.#heldKeys.has(key))) return false;
+
+    return true;
+  }
+
+  #activate({ on: element, with: value, path = [] }) {
+    const tag = element.tagName.toLowerCase();
+    const id = element.id ? `#${element.id}` : "";
+
+    const delegateEvent = new CustomEvent("attractive:hotkey", {
+      cancelable: true,
+      detail: { path }
+    });
+
+    if (!element.dispatchEvent(delegateEvent)) return;
+
+    if (editableElement(element)) {
+      Debug.log(`hotkey → ${tag}${id} [focus]`);
+      element.focus();
+    } else if (value) {
+      Debug.log(`hotkey → ${tag}${id} [${value}]`);
+      element.dispatchEvent(new Event("hotkey", { bubbles: true }));
+    } else {
+      Debug.log(`hotkey → ${tag}${id} [click]`);
+      element.click();
+    }
+  }
+
+  #resetSequence({ on: element }) {
+    const tag = element.tagName.toLowerCase();
+    const id = element.id ? `#${element.id}` : "";
+
+    Debug.log(`hotkey sequence reset → ${tag}${id}`);
+    clearTimeout(this.#sequenceState.get(element)?.timeout);
+    this.#sequenceState.delete(element);
+  }
+
+  #startSequence({ on: element, sequence }) {
+    const tag = element.tagName.toLowerCase();
+    const id = element.id ? `#${element.id}` : "";
+    const keys = `${sequence[0]}→${sequence[1]}`;
+
+    Debug.log(`hotkey sequence ${keys} → ${tag}${id}`);
+    const timeout = setTimeout(
+      () => this.#sequenceState.delete(element),
+      this.#sequenceTimeout
+    );
+
+    this.#sequenceState.set(element, { position: 1, timeout });
+  }
+
+  #advanceSequence({ for: event, on: element, step, sequence, with: value }) {
+    clearTimeout(step.timeout);
+
+    step.position++;
+
+    if (step.position >= sequence.length) {
+      const tag = element.tagName.toLowerCase();
+      const id = element.id ? `#${element.id}` : "";
+
+      Debug.log(`hotkey sequence complete → ${tag}${id}`);
+      this.#sequenceState.delete(element);
+      this.#activate({ on: element, with: value, path: sequence });
+
+      return true;
+    }
+
+    const tag = element.tagName.toLowerCase();
+    const id = element.id ? `#${element.id}` : "";
+
+    Debug.log(`hotkey sequence ${sequence[step.position]} → ${tag}${id}`);
+    step.timeout = setTimeout(
+      () => this.#sequenceState.delete(element),
+      this.#sequenceTimeout
+    );
+
+    return false;
+  }
+}
+
+export const hotkey = new Hotkey();

--- a/src/addons/keyboard/index.js
+++ b/src/addons/keyboard/index.js
@@ -1,0 +1,57 @@
+import { hotkey } from "./hotkey.js";
+import activeEditableElement from "./active_editable_element.js";
+
+export const enter = (event) =>
+  event.type === "hotkey" || event.key === "Enter";
+
+export const escape = (event) =>
+  event.type === "hotkey" || event.key === "Escape";
+
+export const space = (event) => event.type === "hotkey" || event.key === " ";
+
+export const tab = (event) => event.type === "hotkey" || event.key === "Tab";
+
+export const arrowup = (event) =>
+  event.type === "hotkey" || event.key === "ArrowUp";
+
+export const arrowdown = (event) =>
+  event.type === "hotkey" || event.key === "ArrowDown";
+
+export const arrowleft = (event) =>
+  event.type === "hotkey" || event.key === "ArrowLeft";
+
+export const arrowright = (event) =>
+  event.type === "hotkey" || event.key === "ArrowRight";
+
+export const ctrl = (event) => event.type === "hotkey" || event.ctrlKey;
+
+export const alt = (event) => event.type === "hotkey" || event.altKey;
+
+export const shift = (event) => event.type === "hotkey" || event.shiftKey;
+
+export const meta = (event) => event.type === "hotkey" || event.metaKey;
+
+export function keyboard({ instance, registry }) {
+  registry.addEventModifier("enter", enter);
+  registry.addEventModifier("escape", escape);
+  registry.addEventModifier("space", space);
+  registry.addEventModifier("tab", tab);
+  registry.addEventModifier("arrowup", arrowup);
+  registry.addEventModifier("arrowdown", arrowdown);
+  registry.addEventModifier("arrowleft", arrowleft);
+  registry.addEventModifier("arrowright", arrowright);
+  registry.addEventModifier("ctrl", ctrl);
+  registry.addEventModifier("alt", alt);
+  registry.addEventModifier("shift", shift);
+  registry.addEventModifier("meta", meta);
+
+  registry.addEventModifier("window", (event) => {
+    if (event.type.startsWith("key") && activeEditableElement()) return false;
+  });
+
+  registry.addEventModifier("document", (event) => {
+    if (event.type.startsWith("key") && activeEditableElement()) return false;
+  });
+
+  hotkey.setup(instance);
+}

--- a/src/attractive.js
+++ b/src/attractive.js
@@ -7,9 +7,12 @@ import Observer from "./core/observer";
 import EventListeners from "./core/event_listeners";
 import ActionController from "./core/action_controller";
 import { actionAttributes } from "./core/attributes";
+import { defaultEventModifier } from "./core/default_event_modifier";
 import Debug from "./debug";
 
 class Attractive {
+  static #extensions = new Set();
+
   #registry = new Registry();
   #events;
   #eventTypes;
@@ -19,6 +22,12 @@ class Attractive {
   #controller;
   #initialized = false;
   #hooks = new Hooks();
+  #elementAddedHooks = new Set();
+  #elementRemovedHooks = new Set();
+  #beforeRemoveHooks = new Set();
+  #eventSubscriptions = new Map();
+  #attributePrefixes = new Set();
+  #scope;
 
   static activate(options = {}) {
     const instance = new this(options);
@@ -26,6 +35,16 @@ class Attractive {
     instance.activate(options);
 
     return instance;
+  }
+
+  static extend(extensions) {
+    if (Array.isArray(extensions)) {
+      extensions.forEach((extension) => this.#extensions.add(extension));
+    } else {
+      this.#extensions.add(extensions);
+    }
+
+    return this;
   }
 
   /**
@@ -82,6 +101,8 @@ class Attractive {
     this.#listeners = new EventListeners((event, context) =>
       this.#controller.process(event, context)
     );
+
+    defaultEventModifier(this.#registry);
   }
 
   /**
@@ -107,7 +128,10 @@ class Attractive {
 
     if (this.#initialized) return this;
 
+    this.#scope = on;
+
     this.#controller = new ActionController(
+      this.#registry,
       this.#events,
       this.#eventTypes,
       this.#directives,
@@ -116,23 +140,42 @@ class Attractive {
     );
 
     this.#observe = new Observer(
-      (element) => this.#controller.prepare(element),
-      (element) => this.#listeners.cleanup(element),
-      on
+      (element) => {
+        this.#controller.prepare(element);
+        this.#elementAddedHooks.forEach((hook) => hook(element));
+      },
+      (element) => {
+        this.#listeners.cleanup(element);
+        this.#elementRemovedHooks.forEach((hook) => hook(element));
+      },
+      on,
+      (element) => {
+        this.#beforeRemoveHooks.forEach((hook) => hook(element));
+      }
     );
-
-    this.#observe.start(actionAttributes);
 
     const elements = on.querySelectorAll("*");
     const actionElements = [];
 
     for (const element of elements) {
-      if (actionAttributes(element)) {
+      if (this.#hasActionAttribute(element)) {
         actionElements.push(element);
       }
     }
 
-    actionElements.forEach((element) => this.#controller.prepare(element));
+    actionElements.forEach((element) => {
+      this.#controller.prepare(element);
+    });
+
+    for (const extension of Attractive.#extensions) {
+      extension({ instance: this, registry: this.#registry });
+    }
+
+    this.#observe.start((element) => this.#hasActionAttribute(element));
+
+    actionElements.forEach((element) => {
+      this.#elementAddedHooks.forEach((hook) => hook(element));
+    });
 
     this.#initialized = true;
 
@@ -279,7 +322,62 @@ class Attractive {
     return this;
   }
 
+  onElementAdded(callback) {
+    this.#elementAddedHooks.add(callback);
+
+    return this;
+  }
+
+  onElementRemoved(callback) {
+    this.#elementRemovedHooks.add(callback);
+
+    return this;
+  }
+
+  onBeforeElementRemoved(callback) {
+    this.#beforeRemoveHooks.add(callback);
+
+    return this;
+  }
+
+  addEventListener(type, callback) {
+    if (!this.#eventSubscriptions.has(type)) {
+      const listener = (event) => {
+        this.#eventSubscriptions
+          .get(type)
+          .subscriptions.forEach((fn) => fn(event));
+      };
+
+      (this.#scope || document).addEventListener(type, listener);
+
+      this.#eventSubscriptions.set(type, {
+        listener,
+        subscriptions: new Set()
+      });
+    }
+
+    this.#eventSubscriptions.get(type).subscriptions.add(callback);
+
+    return this;
+  }
+
+  observeAttribute(prefix) {
+    this.#attributePrefixes.add(prefix);
+
+    return this;
+  }
+
   // private
+
+  #hasActionAttribute(element) {
+    if (actionAttributes(element)) return true;
+
+    return Array.from(this.#attributePrefixes).some((prefix) =>
+      Array.from(element.attributes).some((attribute) =>
+        attribute.name.startsWith(prefix)
+      )
+    );
+  }
 
   /**
    * Registers the default built-in actions.
@@ -305,6 +403,18 @@ class Attractive {
     return this;
   }
 
+  extend(extensions) {
+    if (Array.isArray(extensions)) {
+      extensions.forEach((extension) =>
+        extension({ instance: this, registry: this.#registry })
+      );
+    } else {
+      extensions({ instance: this, registry: this.#registry });
+    }
+
+    return this;
+  }
+
   /**
    * Deactivates the instance, removing all event listeners and observer.
    *
@@ -318,6 +428,21 @@ class Attractive {
     if (this.#observe) {
       this.#observe.stop();
     }
+
+    this.#eventSubscriptions.forEach((subscription, type) => {
+      (this.#scope || document).removeEventListener(
+        type,
+        subscription.listener
+      );
+      subscription.subscriptions.clear();
+    });
+
+    this.#eventSubscriptions.clear();
+
+    this.#elementAddedHooks.clear();
+    this.#elementRemovedHooks.clear();
+    this.#beforeRemoveHooks.clear();
+    this.#attributePrefixes.clear();
 
     this.#initialized = false;
 

--- a/src/core/action_controller.js
+++ b/src/core/action_controller.js
@@ -13,6 +13,7 @@ class ActionController {
     "scroll"
   ]);
 
+  #registry;
   #events;
   #eventTypes;
   #directives;
@@ -20,7 +21,8 @@ class ActionController {
   #element;
   #scope;
 
-  constructor(events, eventTypes, directives, listeners, element) {
+  constructor(registry, events, eventTypes, directives, listeners, element) {
+    this.#registry = registry;
     this.#events = events;
     this.#eventTypes = eventTypes;
     this.#directives = directives;
@@ -54,10 +56,13 @@ class ActionController {
 
     const attributes = getActionAttributes({ on: element });
 
-    for (const { event: eventName, value } of attributes) {
+    for (const { event: eventName, modifiers, value } of attributes) {
       const eventType = eventName !== null ? eventName : defaultEventType;
 
       if (eventType !== event.type) continue;
+
+      if (this.#blockedByEventModifiers({ for: event, on: element, modifiers }))
+        continue;
 
       this.#events.process(event, {
         on: element,
@@ -68,6 +73,18 @@ class ActionController {
   }
 
   // private
+
+  #blockedByEventModifiers({ for: event, on: element, modifiers }) {
+    return modifiers.some((name) => {
+      const eventModifier = this.#registry.getEventModifier(name);
+
+      if (eventModifier) return eventModifier(event, element) === false;
+
+      if (event.key === undefined) return false;
+
+      return event.key.toLowerCase() !== name.toLowerCase();
+    });
+  }
 
   #registerDirectListeners({ on: element, from: attributes }) {
     for (const { event: eventName, modifiers, value } of attributes) {

--- a/src/core/attributes.js
+++ b/src/core/attributes.js
@@ -8,6 +8,8 @@ const RESERVED = new Set([
 ]);
 
 export function actionAttributes(element) {
+  if (!element || !element.attributes) return false;
+
   for (const attribute of element.attributes) {
     if (RESERVED.has(attribute.name)) continue;
     if (attribute.name.startsWith("@")) return true;
@@ -46,7 +48,7 @@ function parseAttribute(name, value) {
 
   const parts = name.slice(1).split(".");
   const event = parts[0];
-  const modifiers = parts.slice(1);
+  const modifiers = parts.slice(1).flatMap((part) => part.split("+"));
 
   return { event, modifiers, value };
 }

--- a/src/core/default_event_modifier.js
+++ b/src/core/default_event_modifier.js
@@ -1,0 +1,4 @@
+export function defaultEventModifier(registry) {
+  registry.addEventModifier("window", () => true);
+  registry.addEventModifier("document", () => true);
+}

--- a/src/core/observer.js
+++ b/src/core/observer.js
@@ -3,12 +3,19 @@ import Debug from "./../debug";
 class Observer {
   #prepare;
   #cleanup;
+  #beforeCleanup;
   #observer;
   #scope;
 
-  constructor(prepare, cleanup = null, scope = document.documentElement) {
+  constructor(
+    prepare,
+    cleanup = null,
+    scope = document.documentElement,
+    beforeCleanup = null
+  ) {
     this.#prepare = prepare;
     this.#cleanup = cleanup;
+    this.#beforeCleanup = beforeCleanup;
     this.#scope = scope;
   }
 
@@ -36,7 +43,7 @@ class Observer {
         this.#prepare(element);
       });
 
-      if (this.#cleanup) {
+      if (this.#beforeCleanup || this.#cleanup) {
         removed.forEach((element) => {
           Debug.log(
             "Element removed:",
@@ -44,7 +51,8 @@ class Observer {
             "#" + (element.id || "")
           );
 
-          this.#cleanup(element);
+          this.#beforeCleanup?.(element);
+          this.#cleanup?.(element);
         });
       }
     });

--- a/src/core/registry.js
+++ b/src/core/registry.js
@@ -1,6 +1,7 @@
 class Registry {
   #actions = new Map();
   #directives = new Map();
+  #eventModifiers = new Map();
   #activeActions = null;
 
   addAction(name, action, group = null) {
@@ -37,6 +38,14 @@ class Registry {
 
   hasDirective(name) {
     return this.#directives.has(name);
+  }
+
+  addEventModifier(name, eventModifier) {
+    this.#eventModifiers.set(name, eventModifier);
+  }
+
+  getEventModifier(name) {
+    return this.#eventModifiers.get(name);
   }
 }
 

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -5,6 +5,8 @@ import builtinActions from "../src/actions/index.js";
 import { defaultDirectives } from "../src/core/builtin_directives.js";
 import { addClass, removeClass } from "../src/actions/class.js";
 import { remove } from "../src/actions/element.js";
+import { keyboard } from "../src/addons/keyboard/index.js";
+import { hotkey } from "../src/addons/keyboard/hotkey.js";
 
 globalThis.Node = globalThis.Node || { ELEMENT_NODE: 1 };
 
@@ -809,5 +811,470 @@ describe("Core build with selective actions", () => {
     document.querySelector("template").click();
 
     expect(focusSpy).toHaveBeenCalled();
+  });
+});
+
+describe("Extend", () => {
+  test("accepts an array of extensions", async () => {
+    const attractive = new CoreAttractive();
+
+    attractive.addAction("addClass", addClass);
+    attractive.registerDirectives((directives) => {
+      defaultDirectives(directives);
+    });
+
+    const first = vi.fn();
+    const second = vi.fn();
+
+    attractive.extend([first, second]);
+    attractive.activate();
+
+    expect(first).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instance: attractive,
+        registry: expect.anything()
+      })
+    );
+    expect(second).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instance: attractive,
+        registry: expect.anything()
+      })
+    );
+  });
+});
+
+describe("Keyboard addon", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    vi.clearAllTimers();
+    vi.useFakeTimers();
+    hotkey.clearSequenceState();
+
+    attractive = new Attractive();
+
+    attractive.registerActions((registry) => {
+      Object.entries(builtinActions).forEach(([name, action]) =>
+        registry.addAction(name, action)
+      );
+    });
+
+    attractive.registerDirectives((directives) => {
+      defaultDirectives(directives);
+    });
+  });
+
+  test("@keydown.enter fires only on Enter key", async () => {
+    attractive.extend(keyboard);
+    attractive.activate();
+
+    document.body.innerHTML = `
+      <input id="input" @keydown.enter="addClass#enter" @target="target" />
+      <span id="target">Target</span>
+    `;
+
+    await vi.runAllTimersAsync();
+
+    const target = document.getElementById("target");
+    const input = document.getElementById("input");
+
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true })
+    );
+
+    expect(target.classList.contains("enter")).toBe(true);
+  });
+
+  test("@keydown.enter does not fire on other keys", async () => {
+    attractive.extend(keyboard);
+    attractive.activate();
+
+    document.body.innerHTML = `
+      <input id="input" @keydown.enter="addClass#enter" @target="target" />
+      <span id="target">Target</span>
+    `;
+
+    await vi.runAllTimersAsync();
+
+    const target = document.getElementById("target");
+    const input = document.getElementById("input");
+
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { key: " ", bubbles: true })
+    );
+
+    expect(target.classList.contains("enter")).toBe(false);
+  });
+
+  test("@keydown.escape fires only on Escape key", async () => {
+    attractive.extend(keyboard);
+    attractive.activate();
+
+    document.body.innerHTML = `
+      <input id="input" @keydown.escape="addClass#escape" @target="target" />
+      <span id="target">Target</span>
+    `;
+
+    await vi.runAllTimersAsync();
+
+    const target = document.getElementById("target");
+    const input = document.getElementById("input");
+
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true })
+    );
+
+    expect(target.classList.contains("escape")).toBe(true);
+  });
+
+  test("@keydown.ctrl.k fires on Ctrl+K combo", async () => {
+    attractive.extend(keyboard);
+    attractive.activate();
+
+    document.body.innerHTML = `
+      <input id="input" @keydown.ctrl.k="addClass#combo" @target="target" />
+      <span id="target">Target</span>
+    `;
+
+    await vi.runAllTimersAsync();
+
+    const target = document.getElementById("target");
+    const input = document.getElementById("input");
+
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "k", ctrlKey: true, bubbles: true })
+    );
+
+    expect(target.classList.contains("combo")).toBe(true);
+  });
+
+  test("@keydown.ctrl.k does not fire on K without Ctrl", async () => {
+    attractive.extend(keyboard);
+    attractive.activate();
+
+    document.body.innerHTML = `
+      <input id="input" @keydown.ctrl.k="addClass#combo" @target="target" />
+      <span id="target">Target</span>
+    `;
+
+    await vi.runAllTimersAsync();
+
+    const target = document.getElementById("target");
+    const input = document.getElementById("input");
+
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "k", ctrlKey: false, bubbles: true })
+    );
+
+    expect(target.classList.contains("combo")).toBe(false);
+  });
+
+  test("@keydown without modifiers still fires on any key", async () => {
+    attractive.extend(keyboard);
+    attractive.activate();
+
+    document.body.innerHTML = `
+      <input id="input" @keydown="addClass#pressed" @target="target" />
+      <span id="target">Target</span>
+    `;
+
+    await vi.runAllTimersAsync();
+
+    const target = document.getElementById("target");
+    const input = document.getElementById("input");
+
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "a", bubbles: true })
+    );
+
+    expect(target.classList.contains("pressed")).toBe(true);
+  });
+
+  test("keyboard addon does not break @click.window", async () => {
+    attractive.extend(keyboard);
+    attractive.activate();
+
+    document.body.innerHTML = `
+      <div id="outer" @click.window="addClass#clicked:whenOutside" @target="target">
+        <div id="inner">Inside</div>
+      </div>
+      <div id="outside">Outside</div>
+      <span id="target">Target</span>
+    `;
+
+    await vi.runAllTimersAsync();
+
+    const target = document.getElementById("target");
+
+    document.getElementById("outside").click();
+
+    expect(target.classList.contains("clicked")).toBe(true);
+  });
+
+  test("keyboard addon does not break regular click events", async () => {
+    attractive.extend(keyboard);
+    attractive.activate();
+
+    document.body.innerHTML = `
+      <button id="btn" @click="addClass#clicked" @target="target">
+        <span id="target">Target</span>
+      </button>
+    `;
+
+    await vi.runAllTimersAsync();
+
+    const target = document.getElementById("target");
+
+    document.getElementById("btn").click();
+
+    expect(target.classList.contains("clicked")).toBe(true);
+  });
+
+  test("@hotkey.escape with value executes action", async () => {
+    attractive.extend(keyboard);
+    attractive.activate();
+
+    document.body.innerHTML = `
+      <div @hotkey.escape="addClass#fired" @target="target"></div>
+      <span id="target">Target</span>
+    `;
+
+    await vi.runAllTimersAsync();
+
+    const target = document.getElementById("target");
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true })
+    );
+
+    expect(target.classList.contains("fired")).toBe(true);
+  });
+
+  test("@hotkey.ctrl+k with value fires on combo", async () => {
+    attractive.extend(keyboard);
+    attractive.activate();
+
+    document.body.innerHTML = `
+      <div @hotkey.ctrl+k="addClass#fired" @target="target"></div>
+      <span id="target">Target</span>
+    `;
+
+    await vi.runAllTimersAsync();
+
+    const target = document.getElementById("target");
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "k", ctrlKey: true, bubbles: true })
+    );
+
+    expect(target.classList.contains("fired")).toBe(true);
+  });
+
+  test("@hotkey.ctrl+k does not fire on K without Ctrl", async () => {
+    attractive.extend(keyboard);
+    attractive.activate();
+
+    document.body.innerHTML = `
+      <div @hotkey.ctrl+k="addClass#fired" @target="target"></div>
+      <span id="target">Target</span>
+    `;
+
+    await vi.runAllTimersAsync();
+
+    const target = document.getElementById("target");
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "k", ctrlKey: false, bubbles: true })
+    );
+
+    expect(target.classList.contains("fired")).toBe(false);
+  });
+
+  test("@hotkey.g.i sequence fires after g then i", async () => {
+    attractive.extend(keyboard);
+    attractive.activate();
+
+    document.body.innerHTML = `
+      <div @hotkey.g.i="addClass#fired" @target="target"></div>
+      <span id="target">Target</span>
+    `;
+
+    await vi.runAllTimersAsync();
+
+    const target = document.getElementById("target");
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "g", bubbles: true })
+    );
+
+    expect(target.classList.contains("fired")).toBe(false);
+
+    document.dispatchEvent(
+      new KeyboardEvent("keyup", { key: "g", bubbles: true })
+    );
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "i", bubbles: true })
+    );
+
+    await vi.runAllTimersAsync();
+
+    expect(target.classList.contains("fired")).toBe(true);
+  });
+
+  test("bare @hotkey.escape triggers click on element", async () => {
+    attractive.extend(keyboard);
+    attractive.activate();
+
+    document.body.innerHTML = `
+      <button @hotkey.escape id="btn">Close</button>
+    `;
+
+    await vi.runAllTimersAsync();
+
+    const btn = document.getElementById("btn");
+    const clicked = vi.fn();
+
+    btn.addEventListener("click", clicked);
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true })
+    );
+
+    expect(clicked).toHaveBeenCalled();
+  });
+
+  test("@hotkey.g+i fires when both keys are held", async () => {
+    attractive.extend(keyboard);
+    attractive.activate();
+
+    document.body.innerHTML = `
+      <div @hotkey.g+i="addClass#fired" @target="target"></div>
+      <span id="target">Target</span>
+    `;
+
+    await vi.runAllTimersAsync();
+
+    const target = document.getElementById("target");
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "g", bubbles: true })
+    );
+
+    expect(target.classList.contains("fired")).toBe(false);
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "i", bubbles: true })
+    );
+
+    await vi.runAllTimersAsync();
+
+    expect(target.classList.contains("fired")).toBe(true);
+  });
+
+  test("@hotkey.g+i combo clears held keys after firing", async () => {
+    attractive.extend(keyboard);
+    attractive.activate();
+
+    document.body.innerHTML = `
+      <div @hotkey.g+i="addClass#fired" @target="target"></div>
+      <span id="target">Target</span>
+    `;
+
+    await vi.runAllTimersAsync();
+
+    const target = document.getElementById("target");
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "g", bubbles: true })
+    );
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "i", bubbles: true })
+    );
+
+    await vi.runAllTimersAsync();
+
+    expect(target.classList.contains("fired")).toBe(true);
+
+    target.classList.remove("fired");
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "g", bubbles: true })
+    );
+
+    await vi.runAllTimersAsync();
+
+    expect(target.classList.contains("fired")).toBe(false);
+  });
+
+  test("@hotkey.g+i combo does not fire after keyup", async () => {
+    attractive.extend(keyboard);
+    attractive.activate();
+
+    document.body.innerHTML = `
+      <div @hotkey.g+i="addClass#fired" @target="target"></div>
+      <span id="target">Target</span>
+    `;
+
+    await vi.runAllTimersAsync();
+
+    const target = document.getElementById("target");
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "g", bubbles: true })
+    );
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "i", bubbles: true })
+    );
+
+    await vi.runAllTimersAsync();
+
+    expect(target.classList.contains("fired")).toBe(true);
+
+    target.classList.remove("fired");
+
+    document.dispatchEvent(
+      new KeyboardEvent("keyup", { key: "g", bubbles: true })
+    );
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "g", bubbles: true })
+    );
+
+    await vi.runAllTimersAsync();
+
+    expect(target.classList.contains("fired")).toBe(false);
+  });
+
+  test("@hotkey.g+i combo fires alongside same-key sequence", async () => {
+    attractive.extend(keyboard);
+    attractive.activate();
+
+    document.body.innerHTML = `
+      <div @hotkey.g.i="addClass#seq" @target="seqTarget"></div>
+      <div @hotkey.g+i="addClass#combo" @target="comboTarget"></div>
+      <span id="seqTarget">Seq</span>
+      <span id="comboTarget">Combo</span>
+    `;
+
+    await vi.runAllTimersAsync();
+
+    const seqTarget = document.getElementById("seqTarget");
+    const comboTarget = document.getElementById("comboTarget");
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "g", bubbles: true })
+    );
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "i", bubbles: true })
+    );
+
+    await vi.runAllTimersAsync();
+
+    expect(seqTarget.classList.contains("seq")).toBe(false);
+    expect(comboTarget.classList.contains("combo")).toBe(true);
   });
 });


### PR DESCRIPTION
Add optional functionality. It extends keyboard events with "modifier":
```html
<button @keydown.ctrl+k="focus" @target="search" />
```

It also adds a `@hotkey` shortcut:
```
<button @hotkey.ctrl+k="focus" @target="search">Search</button>
```

Without an action, it triggers a `click` (or focus on focusable elements):
```
<a @hotkey.g.i href="/inbox">Inbox</a>
```