### PR TITLE
Added `reactive` addon

### DIFF
--- a/docs/app/assets/stylesheets/components/content.css
+++ b/docs/app/assets/stylesheets/components/content.css
@@ -197,20 +197,27 @@
 
       .anchor {
         scroll-margin-top: 3rem;
+        display: inline-block;
+        width: .675rem; height: auto;
+        aspect-ratio: 1;
+        font-size: .675em;
+        line-height: 1;
+        font-weight: 400;
+        text-decoration: none;
+        color: var(--gray-400);
+
+        &:hover {
+          color: var(--brand-400);
+        }
 
         &::before {
           content: "#";
-          display: inline-block;
-          width: 1rem; height: 1rem;
-          font-size: .75em;
-          font-weight: 400;
-          color: var(--gray-500);
           opacity: 0;
         }
       }
 
       @media (hover: hover) and (width >= 1024px) {
-        margin-left: -1.25rem;
+        margin-left: -.875rem;
 
         &:hover .anchor::before {
           opacity: 1;

--- a/docs/app/content/actions/reload.md
+++ b/docs/app/content/actions/reload.md
@@ -1,7 +1,7 @@
 ---
 title: reload
 group: reload
-description: Reload elements by target or the current page via `@target: "window"`
+description: "Reload elements by target or the current page via `@target: 'window'`"
 position: 1
 ---
 

--- a/docs/app/content/articles/custom-actions.md
+++ b/docs/app/content/articles/custom-actions.md
@@ -58,7 +58,7 @@ You can also batch register multiple actions at once with `addActions({ sharePag
 
 ## addTrigger
 
-Triggers fire the action when a condition is met (rather than on a user event). The function receives `(element, fire)` — call `fire()` to execute the action.
+Triggers fire the action when a condition is met (rather than on a user event). The function receives `(element, fire)`. Call `fire()` to execute the action.
 ```js
 attractive.addTrigger("onceTurboLoaded", (element, fire) => {
   document.addEventListener("turbo:load", fire, { once: true });

--- a/docs/app/content/articles/events.md
+++ b/docs/app/content/articles/events.md
@@ -19,11 +19,6 @@ position: 3
 | `<select>`       | `change`      |
 | `<form>`         | `submit`      |
 
-```html
-<button @action="toggleClass#active">Toggle</button>
-<input @action="addClass#visible">
-```
-
 
 ## Explicit events
 
@@ -31,7 +26,7 @@ Use the event name as the attribute to override the default:
 
 ```html
 <button @mouseenter="addClass#hovered" @mouseleave="removeClass#hovered">Hover</button>
-<input @change="addClass#dirty">
+<input @input="addClass#dirty">
 <button @dblclick="toggleClass#selected" />
 <input @focus="addClass#focused" @blur="removeClass#focused" />
 ```

--- a/docs/app/content/articles/installation.md
+++ b/docs/app/content/articles/installation.md
@@ -5,7 +5,7 @@ category: get-started
 position: 3
 ---
 
-Install Attractive.js via npm or your package manager of choice.
+Install Attractive.js via pnpm or your package manager of choice.
 
 
 ## pnpm
@@ -21,31 +21,33 @@ pnpm add attractivejs
 npm install attractivejs
 ```
 
-
-## yarn
-
-```bash
-yarn add attractivejs
-```
-
-
-Then import it into your JavaScript entrypoint and activate it. 🧲
+Then import it into your JavaScript entrypoint and activate it.
 ```js
 import Attractive from "attractivejs";
 
-const attractive = Attractive.activate();
+Attractive.activate();
 ```
+
+
+## CDN
+
+```html
+<script type="module">
+  import Attractive from "//unpkg.com/attractivejs@latest/dist/attractive.min.js";
+
+  Attractive.activate();
+</script>
+```
+
 
 By default, Attractive observes the entire `document`. Pass a specific element to scope it:
 ```js
-const attractive = Attractive.activate({
-  on: document.getElementById("sidebar")
-});
+Attractive.activate({ on: document.getElementById("sidebar") });
 ```
 
 Enable debug logging:
 ```js
-const attractive = Attractive.activate({ debug: true });
+Attractive.activate({ debug: true });
 ```
 
 
@@ -55,4 +57,4 @@ const attractive = Attractive.activate({ debug: true });
 Attractive.activate().withActions(["class", "attribute"]);
 ```
 
-Only the `class` and `attribute` actions will be available.
+Only the `class` and `attribute` actions will be available. [Read also about core](/docs/core-build/) if you want to tree-shakeable actions.

--- a/docs/app/content/articles/keyboard.md
+++ b/docs/app/content/articles/keyboard.md
@@ -7,23 +7,16 @@ position: 1
 
 Keyboard adds key-filter dot modifiers for `@keydown` and global `@hotkey` shortcuts.
 
+
 ## Usage
 
 ```js
 import Attractive from "attractivejs";
 import { keyboard } from "attractivejs/keyboard";
 
-Attractive.extend(keyboard);
-
-const attractive = Attractive.activate();
+Attractive.activate({ extendWith: [keyboard] });
 ```
 
-Or per-instance:
-
-```js
-const attractive = Attractive.activate();
-attractive.extend(keyboard);
-```
 
 ## @keydown vs @hotkey
 
@@ -32,19 +25,19 @@ attractive.extend(keyboard);
 | `@keydown.*` | Element — must be focused |
 | `@hotkey.*`  | Global — suppressed when editing form fields |
 
+
 ## @keydown
 
 Dot modifiers filter which keys trigger the action. The element must be focused for `@keydown` to fire:
-
 ```html
 <input @keydown.enter="addClass#submitted" @target="status" />
 ```
 
 Children of the focused element also trigger it, since events bubble:
-
 ```html
 <form @keydown.enter="addClass#searching" @target="results">
   <input name="q" />
+
   <button>Search</button>
 </form>
 ```
@@ -67,26 +60,25 @@ Children of the focused element also trigger it, since events bubble:
 | `.document`   | Listens on `document` instead |
 
 A bare `@keydown` fires on any key:
-
 ```html
 <input @keydown="addClass#pressed" @target="status" />
 ```
 
 Multiple keys combine with `+`:
-
 ```html
 <input @keydown.ctrl+k="focus" @target="search-field" />
 <input @keydown.shift+enter="addClass#submitted" @target="status" />
 ```
 
+
 ### Global with `.window`
 
 Add `.window` to fire globally regardless of element focus. Editable elements (input, textarea, select, contenteditable) suppress the action when focused:
-
 ```html
 <div @keydown.meta+s.window="addClass#saved" @target="status">Save</div>
 <div @keydown.escape.window="removeAttribute#open" @target="menu">Close</div>
 ```
+
 
 ## @hotkey
 
@@ -101,6 +93,7 @@ Without a value, `@hotkey` calls `element.click()`:
 <button @hotkey.escape @action="removeAttribute#open" @target="menu">Close</button>
 ```
 
+
 ### Valued hotkey
 
 With a value, `@hotkey` dispatches a synthetic `hotkey` event through the action pipeline:
@@ -108,6 +101,7 @@ With a value, `@hotkey` dispatches a synthetic `hotkey` event through the action
 <button @hotkey.escape="removeAttribute#open" @target="menu">Close</button>
 <button @hotkey.ctrl+k="focus" @target="search">Search</button>
 ```
+
 
 ### Hotkey syntax
 
@@ -119,13 +113,10 @@ With a value, `@hotkey` dispatches a synthetic `hotkey` event through the action
 | Combo (+)  | `@hotkey.ctrl+k`    | `Ctrl` and `K` are held simultaneously     |
 | Sequence   | `@hotkey.g.i`       | `G` is pressed, released, then ``I`` pressed |
 
-- `+` separates keys pressed simultaneously (combo): `@hotkey.ctrl+shift+z`
-- `.` separates sequential steps: `@hotkey.g.i` (g then i)
 
 ### Cancellable event
 
 Before the action fires, `@hotkey` dispatches a cancellable `attractive:hotkey` CustomEvent on the element. Call `preventDefault()` to stop the action:
-
 ```js
 element.addEventListener("attractive:hotkey", (event) => {
   if (someCondition) event.preventDefault();
@@ -133,6 +124,7 @@ element.addEventListener("attractive:hotkey", (event) => {
 ```
 
 The event `detail` includes the matched key `path` array.
+
 
 ### Focus vs click
 

--- a/docs/app/content/articles/reactive.md
+++ b/docs/app/content/articles/reactive.md
@@ -1,0 +1,91 @@
+---
+title: Reactive
+description: "Reactive key-value store with DOM bindings: set, get, auto-update text content and store-driven action triggers"
+category: extensions
+position: 2
+---
+
+Reactive adds a shared key-value store with `@text` DOM bindings, `setStore` action and `whenTrue`/`whenFalse` triggers.
+
+
+## Usage
+
+```js
+import Attractive from "attractivejs";
+import { reactive, store } from "attractivejs/reactive";
+
+Attractive.activate({ extendWith: [reactive] });
+```
+
+
+## Store API
+
+The store is a singleton shared by all instances. Write from JavaScript via `store.set()` or from HTML via `setStore`, all subscribers react regardless of source.
+```js
+store.set("name", { with: "Alice" });
+
+store.get("name"); // => "Alice"
+```
+
+
+## `@text` bindings
+
+```html
+<p @text="greeting"></p>
+```
+
+The element's `textContent` updates automatically whenever the store value changes. Shows empty string for `null` or `undefined`.
+
+
+## `setStore` action
+
+Write the element's `value` to the store:
+```html
+<input @input="setStore#search" />
+```
+
+Sets the store key to `true`:
+```html
+<button @click="setStore#active">Activate</button>
+```
+
+Combine with `data-debounce` for rate-limited updates:
+```html
+<input @input="setStore#query" data-debounce="300" />
+```
+
+
+## `:whenTrue` / `:whenFalse` triggers
+
+React to store changes by firing actions when a value enters a specific state. Both read the store key from `data-store`.
+
+Truthy values are anything not `false`, `null`, `undefined`, `0`, `""` or `NaN`.
+
+
+### `:whenTrue`
+
+Fires the action when the store value is truthy:
+```html
+<div @action="addClass#visible:whenTrue" data-store="loaded"></div>
+```
+
+
+### `:whenFalse`
+
+Fires the action when the store value is falsy:
+```html
+<div @action="removeClass#visible:whenFalse" data-store="loaded"></div>
+```
+
+
+### Paired pattern
+
+The common use case is pairing both to handle truthy/falsy transitions:
+```html
+<div
+  @action="addAttribute#open:whenTrue removeAttribute#open:whenFalse"
+  data-store="open"
+></div>
+```
+
+On `store.set("open", { with: true })` the attribute is added. On `store.set("open", { with: false })` it is removed.

--- a/package.json
+++ b/package.json
@@ -81,6 +81,9 @@
     },
     "./keyboard": {
       "import": "./dist/keyboard.js"
+    },
+    "./reactive": {
+      "import": "./dist/reactive.js"
     }
   },
   "files": [

--- a/playground/index.html
+++ b/playground/index.html
@@ -7,82 +7,28 @@
       href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🛝</text></svg>"
     />
     <script type="module">
-      import * as Turbo from "https://unpkg.com/@hotwired/turbo/dist/turbo.es2017-esm.js";
-    </script>
-
-    <script type="module">
       import Attractive from "../dist/attractive.min.js";
-      import { keyboard } from "../dist/keyboard.min.js";
 
-      Attractive.activate({ debug: true }).extend(keyboard);
+      Attractive.activate({ debug: true });
     </script>
   </head>
   <body>
-    <turbo-frame id="demo" src="/playground/turbo.html"> </turbo-frame>
+    <h2>Toggle</h2>
+    <button @action="toggleClass#active" @target="target">Toggle</button>
+    <p id="target">This toggles the <code>active</code> class.</p>
 
-    <button @action="reload" @target="demo">Reload frame</button>
-
-    <button @action="reload.window">Reload page</button>
-
-    <h2>Keyboard</h2>
-
-    <h3>1. global with dot (@hotkey.escape, bare → click delegation)</h3>
-    <p>
-      <button @hotkey.escape @action="removeClass#active" @target="keyTarget1">
-        Press Escape globally
-      </button>
-      <code id="keyTarget1" class="active">target (class reset)</code>
-    </p>
-
-    <h3>2. global with + (@hotkey.ctrl+k, valued → synthetic hotkey event)</h3>
-    <p>
-      <button @hotkey.ctrl+k="addClass#active" @target="keyTarget2">
-        Press Ctrl+K globally
-      </button>
-      <code id="keyTarget2">target (class added)</code>
-    </p>
-
-    <h3>3. hotkey with dot — sequence (@hotkey.g.i, bare → click)</h3>
-    <p>
-      <a @hotkey.g.i @action="toggleClass#active" @target="keyTarget3" href="#">
-        Inbox (press g then i)
-      </a>
-      <code id="keyTarget3">target (toggled)</code>
-    </p>
-
-    <h3>4. hotkey with + — combo (@hotkey.g+i, valued → synthetic event)</h3>
-    <p>
-      <button @hotkey.g+i="toggleClass#active" @target="keyTarget4">
-        Press g+i simultaneously
-      </button>
-      <code id="keyTarget4">target (toggled)</code>
-    </p>
-
-    <h3>5. keydown on input (@keydown, element-scoped)</h3>
-    <p>
-      <input
-        @keydown.meta+enter="addClass#active"
-        @keydown.escape="removeClass#active"
-        @target="kbTarget"
-        placeholder="Focus here, press Cmd+Enter or Escape"
-      />
-      <code id="kbTarget">target</code>
-    </p>
-
-    <h2>Toggle (@="" syntax)</h2>
-    <button @action="toggleClass#active" @target="toggleTarget">Toggle</button>
-    <p id="toggleTarget">This toggles the <code>active</code> class.</p>
-
-    <h2>Copy (old data-action syntax — should warn once)</h2>
-    <button data-action="copy" data-target="copySource">Copy</button>
-    <input id="copySource" value="copied text" readonly />
+    <h2>Copy</h2>
+    <button @action="copy" @target="source">Copy</button>
+    <input id="source" value="copied text" readonly />
 
     <style>
-      [open],
-      [data-open="true"],
       .active {
         color: red;
         font-weight: bold;
+      }
+
+      [data-copy-success="true"] {
+        border-color: aqua;
       }
     </style>
   </body>

--- a/rolldown.config.js
+++ b/rolldown.config.js
@@ -104,5 +104,22 @@ export default [
     }
   }),
 
+  defineConfig({
+    input: "src/addons/reactive/index.js",
+    output: {
+      file: "dist/reactive.js",
+      format: "es"
+    }
+  }),
+
+  defineConfig({
+    input: "src/addons/reactive/index.js",
+    output: {
+      file: "dist/reactive.min.js",
+      format: "es",
+      minify: true
+    }
+  }),
+
   ...actionConfigs
 ];

--- a/src/actions/base.js
+++ b/src/actions/base.js
@@ -1,22 +1,9 @@
 import Debug from "./../debug";
-import debounce from "./../helpers/debounce";
-
-const debounceTimers = new WeakMap();
 
 export default class ActionBase {
   static actionFor(method) {
     return (element, options = {}) => {
       const instance = new this(element, options);
-      const delay = instance.#debounceDelay;
-
-      if (delay > 0) {
-        const timer = debounceTimers.get(element) ?? debounce();
-
-        debounceTimers.set(element, timer);
-        timer(() => instance[method](), delay);
-
-        return;
-      }
 
       return instance[method]();
     };
@@ -29,14 +16,6 @@ export default class ActionBase {
     this.target = options.target;
     this.targetsSelector = options.targets;
     this.options = options;
-  }
-
-  get #debounceDelay() {
-    const dataset = this.currentElement.dataset;
-
-    return parseInt(
-      dataset.debounce ?? dataset.formDebounce ?? dataset.requestDebounce ?? 0
-    );
   }
 
   get targets() {

--- a/src/actions/clipboard.js
+++ b/src/actions/clipboard.js
@@ -1,7 +1,7 @@
 import ActionBase from "./base";
-import debounce from "./../helpers/debounce";
+import delay from "./../helpers/delay";
 
-const debouncedClearingFeedback = debounce();
+const clearFeedback = delay();
 
 class Clipboard extends ActionBase {
   constructor(currentElement, options = {}) {
@@ -36,7 +36,7 @@ class Clipboard extends ActionBase {
 
     if (!delay) return;
 
-    debouncedClearingFeedback(
+    clearFeedback(
       () =>
         this.targets.forEach((target) =>
           target.removeAttribute(this.#attributeName)

--- a/src/actions/confirm.js
+++ b/src/actions/confirm.js
@@ -1,7 +1,7 @@
 import ActionBase from "./base";
-import debounce from "./../helpers/debounce";
+import delay from "./../helpers/delay";
 
-const debouncedClearingFeedback = debounce();
+const clearFeedback = delay();
 
 class Confirm extends ActionBase {
   confirm() {
@@ -21,7 +21,7 @@ class Confirm extends ActionBase {
 
     if (!duration) return;
 
-    debouncedClearingFeedback(
+    clearFeedback(
       () => this.currentElement.removeAttribute("data-confirm-success"),
       parseInt(duration)
     );

--- a/src/actions/request.js
+++ b/src/actions/request.js
@@ -1,8 +1,8 @@
 import ActionBase from "./base";
 import { CSRF } from "./request/csrf";
-import debounce from "./../helpers/debounce";
+import delay from "./../helpers/delay";
 
-const debouncedFeedback = debounce();
+const clearFeedback = delay();
 
 const activeRequests = new WeakMap();
 
@@ -112,7 +112,7 @@ class Request extends ActionBase {
 
     if (!duration || state === "busy") return;
 
-    debouncedFeedback(() => {
+    clearFeedback(() => {
       this.targets.forEach((target) =>
         target.removeAttribute("data-request-success")
       );

--- a/src/addons/README.md
+++ b/src/addons/README.md
@@ -1,15 +1,12 @@
 # Addons
 
-Addons extend Attractive instances with event modifiers, directives and behaviors. Registered via `instance.extend()` or `Attractive.extend()`.
-
-## Usage
+Addons extend Attractive instances with event modifiers, directives and behaviors. Registered per-instance via `extendWith`:
 
 ```js
 import Attractive from "attractivejs";
 import { keyboard } from "attractivejs/keyboard";
 
-const attractive = Attractive.activate();
-attractive.extend(keyboard);
+Attractive.activate({ extendWith: [keyboard] });
 ```
 
 ## Available addons
@@ -17,6 +14,7 @@ attractive.extend(keyboard);
 | Addon    | Import                  | Description                                                              |
 | -------- | ----------------------- | ------------------------------------------------------------------------ |
 | keyboard | `attractivejs/keyboard` | Key-filter dot modifiers (.enter, .escape…) and global @hotkey shortcuts |
+| reactive | `attractivejs/reactive` | Reactive key-value store with `@text` DOM subscriptions                  |
 
 ## Writing an addon
 

--- a/src/addons/reactive/actions/set_store.js
+++ b/src/addons/reactive/actions/set_store.js
@@ -1,0 +1,11 @@
+import { store } from "../store.js";
+
+export function setStore(element, { value: key }) {
+  const tag = element.tagName;
+
+  if (tag === "INPUT" || tag === "SELECT" || tag === "TEXTAREA") {
+    store.set(key, { with: element.value });
+  } else {
+    store.set(key, { with: true });
+  }
+}

--- a/src/addons/reactive/attribute.js
+++ b/src/addons/reactive/attribute.js
@@ -1,0 +1,29 @@
+import { store, has, subscribe } from "./store.js";
+
+const bindings = new WeakMap();
+
+export function bindText({ on: element, with: key }) {
+  if (has(key)) {
+    element.textContent = store.get(key) ?? "";
+  } else {
+    const value = element.textContent;
+
+    if (value) store.set(key, { with: value });
+  }
+
+  const remove = subscribe(key, {
+    with: (value) => {
+      element.textContent = value === null || value === undefined ? "" : value;
+    }
+  });
+
+  bindings.set(element, remove);
+}
+
+export function unbindText(element) {
+  const remove = bindings.get(element);
+  if (!remove) return;
+
+  remove();
+  bindings.delete(element);
+}

--- a/src/addons/reactive/directives.js
+++ b/src/addons/reactive/directives.js
@@ -1,0 +1,49 @@
+import { subscribe } from "./store.js";
+
+const subscriptions = new WeakMap();
+
+function trackSubscription(element, remove) {
+  const trackedSubscriptions = subscriptions.get(element);
+
+  if (trackedSubscriptions) {
+    trackedSubscriptions.push(remove);
+  } else {
+    subscriptions.set(element, [remove]);
+  }
+}
+
+export function whenTrue(element, trigger) {
+  const key = element.dataset.store;
+  if (!key) return;
+
+  trackSubscription(
+    element,
+    subscribe(key, {
+      with: (value) => {
+        if (value) trigger();
+      }
+    })
+  );
+}
+
+export function whenFalse(element, trigger) {
+  const key = element.dataset.store;
+  if (!key) return;
+
+  trackSubscription(
+    element,
+    subscribe(key, {
+      with: (value) => {
+        if (!value) trigger();
+      }
+    })
+  );
+}
+
+export function unbindStore(element) {
+  const trackedSubscriptions = subscriptions.get(element);
+  if (!trackedSubscriptions) return;
+
+  trackedSubscriptions.forEach((remove) => remove());
+  subscriptions.delete(element);
+}

--- a/src/addons/reactive/index.js
+++ b/src/addons/reactive/index.js
@@ -1,0 +1,27 @@
+import { bindText, unbindText } from "./attribute.js";
+import { setStore } from "./actions/set_store.js";
+import { whenTrue, whenFalse, unbindStore } from "./directives.js";
+import { store } from "./store.js";
+
+export { store };
+
+export function reactive({ instance, registry }) {
+  instance.store = store;
+
+  registry.addAction("setStore", setStore);
+  registry.addDirective("whenTrue", whenTrue);
+  registry.addDirective("whenFalse", whenFalse);
+
+  instance.onElementAdded((element) => {
+    const key = element.getAttribute("@text");
+
+    if (!key) return;
+
+    bindText({ on: element, with: key.trim() });
+  });
+
+  instance.onElementRemoved((element) => {
+    unbindText(element);
+    unbindStore(element);
+  });
+}

--- a/src/addons/reactive/store.js
+++ b/src/addons/reactive/store.js
@@ -1,0 +1,35 @@
+const data = new Map();
+const subscriptions = new Map();
+
+export const store = {
+  set(key, { with: value }) {
+    data.set(key, value);
+
+    const trackedSubscriptions = subscriptions.get(key);
+    if (!trackedSubscriptions) return;
+
+    for (const listener of trackedSubscriptions) {
+      listener(value);
+    }
+  },
+
+  get(key) {
+    return data.get(key);
+  }
+};
+
+export function has(key) {
+  return data.has(key);
+}
+
+export function subscribe(key, { with: listener }) {
+  if (!subscriptions.has(key)) {
+    subscriptions.set(key, new Set());
+  }
+
+  subscriptions.get(key).add(listener);
+
+  return () => {
+    subscriptions.get(key)?.delete(listener);
+  };
+}

--- a/src/core.js
+++ b/src/core.js
@@ -21,24 +21,12 @@ class Attractive {
   #subscriptions = new EventSubscriptions();
   #attributePrefixes = new AttributePrefixes();
 
-  static #extensions = new Set();
-
   static activate(options = {}) {
     const instance = new this(options);
 
     instance.activate(options);
 
     return instance;
-  }
-
-  static extend(extensions) {
-    if (Array.isArray(extensions)) {
-      extensions.forEach((extension) => this.#extensions.add(extension));
-    } else {
-      this.#extensions.add(extensions);
-    }
-
-    return this;
   }
 
   /**
@@ -103,8 +91,7 @@ class Attractive {
       elementLifecycle: this.#elementLifecycle,
       subscriptions: this.#subscriptions,
       attributePrefixes: this.#attributePrefixes,
-      owner: this,
-      extensions: Attractive.#extensions
+      owner: this
     });
   }
 
@@ -276,18 +263,6 @@ class Attractive {
    */
   registerDirectives(directivesLoader) {
     directivesLoader(this.#registry);
-
-    return this;
-  }
-
-  extend(extensions) {
-    if (Array.isArray(extensions)) {
-      extensions.forEach((extension) =>
-        extension({ instance: this, registry: this.#registry })
-      );
-    } else {
-      extensions({ instance: this, registry: this.#registry });
-    }
 
     return this;
   }

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -1,4 +1,7 @@
+import debounce from "./../helpers/debounce";
 import { actionAttributes, getActionAttributes } from "./attributes";
+
+const debounceTimers = new WeakMap();
 
 class Actions {
   static #nonBubblingEvents = new Set([
@@ -48,6 +51,36 @@ class Actions {
 
     if (!element) return;
 
+    if (!this.#scope.contains(element)) return;
+
+    const delay = this.#debounceDelay(element);
+
+    if (delay > 0) {
+      let timer = debounceTimers.get(element);
+
+      if (!timer) {
+        timer = debounce();
+        debounceTimers.set(element, timer);
+      }
+
+      timer(() => this.#execute({ event, with: context, on: element }), delay);
+
+      return;
+    }
+
+    this.#execute({ event, with: context, on: element });
+  }
+
+  #debounceDelay(element) {
+    return parseInt(
+      element.dataset.debounce ??
+        element.dataset.formDebounce ??
+        element.dataset.requestDebounce ??
+        0
+    );
+  }
+
+  #execute({ event, with: context, on: element }) {
     if (!this.#scope.contains(element)) return;
 
     const defaultEventType = context

--- a/src/core/activation.js
+++ b/src/core/activation.js
@@ -17,7 +17,6 @@ class Activation {
   #actions;
   #observe;
   #initialized = false;
-  #extensions;
 
   constructor(dependencies) {
     this.#registry = dependencies.registry;
@@ -28,7 +27,6 @@ class Activation {
     this.#subscriptions = dependencies.subscriptions;
     this.#attributePrefixes = dependencies.attributePrefixes;
     this.#owner = dependencies.owner;
-    this.#extensions = dependencies.extensions;
     this.#listeners = new EventListeners((event, context) =>
       this.#actions?.process(event, context)
     );
@@ -39,7 +37,7 @@ class Activation {
   }
 
   activate(options = {}) {
-    const { on = document, debug = false } = options;
+    const { on = document, debug = false, extendWith = [] } = options;
 
     Debug.enabled = debug;
 
@@ -67,12 +65,16 @@ class Activation {
     this.#observe = new Observer(
       (element) => {
         this.#actions.prepare(element);
+
         this.#elementLifecycle.fireAdded(element);
       },
+
       (element) => {
         this.#listeners.cleanup(element);
+
         this.#elementLifecycle.fireRemoved(element);
       },
+
       on,
       (element) => {
         this.#elementLifecycle.fireBeforeRemove(element);
@@ -88,13 +90,13 @@ class Activation {
       }
     }
 
+    for (const extension of extendWith) {
+      extension({ instance: this.#owner, registry: this.#registry });
+    }
+
     actionElements.forEach((element) => {
       this.#actions.prepare(element);
     });
-
-    for (const extension of this.#extensions) {
-      extension({ instance: this.#owner, registry: this.#registry });
-    }
 
     this.#observe.start((element) => this.#attributePrefixes.matches(element));
 

--- a/src/core/events/execute.js
+++ b/src/core/events/execute.js
@@ -120,6 +120,7 @@ class Execute {
   async #invoke({ name, on: element, context: actionContext }) {
     try {
       const actionFunction = this.#registry.getAction(name);
+
       return await actionFunction(element, actionContext);
     } catch (error) {
       this.#handleError({ name, on: element, error });

--- a/src/core/observer.js
+++ b/src/core/observer.js
@@ -1,5 +1,9 @@
 import Debug from "./../debug";
 
+const ELEMENT_NODE = (typeof Node !== "undefined" && Node.ELEMENT_NODE) || 1;
+const ATTRIBUTE_PREFIX = "@";
+const RESERVED_ATTRIBUTES = new Set(["@target", "@targets"]);
+
 class Observer {
   #prepare;
   #cleanup;
@@ -25,13 +29,26 @@ class Observer {
     this.#observer = new MutationObserver((mutations) => {
       const added = new Set();
       const removed = new Set();
+      const changed = new Set();
 
-      mutations.forEach((mutation) =>
-        this.#processMutation(mutation, {
-          for: action,
-          elements: { added, removed }
-        })
-      );
+      for (const mutation of mutations) {
+        if (mutation.type === "childList") {
+          this.#processChildMutation(mutation, {
+            for: action,
+            elements: { added, removed }
+          });
+
+          continue;
+        }
+
+        if (
+          mutation.type === "attributes" &&
+          mutation.attributeName.startsWith(ATTRIBUTE_PREFIX) &&
+          !RESERVED_ATTRIBUTES.has(mutation.attributeName)
+        ) {
+          changed.add(mutation.target);
+        }
+      }
 
       added.forEach((element) => {
         Debug.log(
@@ -55,9 +72,31 @@ class Observer {
           this.#cleanup?.(element);
         });
       }
+
+      if (this.#cleanup) {
+        changed.forEach((element) => {
+          if (removed.has(element)) return;
+
+          Debug.log(
+            "Attribute changed:",
+            element.tagName.toLowerCase(),
+            "#" + (element.id || "")
+          );
+
+          this.#cleanup(element);
+
+          if (action(element)) {
+            this.#prepare(element);
+          }
+        });
+      }
     });
 
-    this.#observer.observe(this.#scope, { childList: true, subtree: true });
+    this.#observer.observe(this.#scope, {
+      childList: true,
+      subtree: true,
+      attributes: true
+    });
 
     return this;
   }
@@ -70,9 +109,10 @@ class Observer {
 
   // private
 
-  #processMutation(mutation, { for: action, elements: { added, removed } }) {
-    if (mutation.type !== "childList") return;
-
+  #processChildMutation(
+    mutation,
+    { for: action, elements: { added, removed } }
+  ) {
     mutation.addedNodes.forEach((node) => {
       this.#processNode(node, { for: action, and: added });
     });
@@ -83,7 +123,7 @@ class Observer {
   }
 
   #processNode(node, { for: action, and: elements }) {
-    if (node.nodeType !== Node.ELEMENT_NODE) return;
+    if (node.nodeType !== ELEMENT_NODE) return;
     if (action(node)) elements.add(node);
     if (!node.querySelectorAll) return;
 

--- a/src/helpers/delay.js
+++ b/src/helpers/delay.js
@@ -1,0 +1,11 @@
+const delay = () => {
+  let timeoutId;
+
+  return (callback, delay) => {
+    clearTimeout(timeoutId);
+
+    timeoutId = setTimeout(callback, delay);
+  };
+};
+
+export default delay;

--- a/tests/actions/base.test.js
+++ b/tests/actions/base.test.js
@@ -1,37 +1,59 @@
 import { describe, test, expect, beforeEach, vi } from "vitest";
-import focusActions from "../../src/actions/focus.js";
+import Attractive from "../../src/index.js";
+import builtinActions from "../../src/actions/index.js";
+import { defaultDirectives } from "../../src/core/builtin_directives.js";
 
-describe("ActionBase - Global Debounce", () => {
-  beforeEach(() => {
+describe("Global Debounce", () => {
+  let attractive;
+
+  beforeEach(async () => {
     document.body.innerHTML = "";
     vi.clearAllTimers();
     vi.useFakeTimers();
+
+    attractive = new Attractive();
+
+    attractive.registerActions((registry) => {
+      Object.entries(builtinActions).forEach(([name, action]) =>
+        registry.addAction(name, action)
+      );
+    });
+
+    attractive.registerDirectives((directives) => {
+      defaultDirectives(directives);
+    });
   });
 
-  test("fires action immediately without data-debounce", () => {
+  test("fires action immediately without data-debounce", async () => {
+    attractive.activate();
+
     document.body.innerHTML = `
-      <button id="trigger">Focus</button>
+      <button id="trigger" @click="focus#target" @target="target">Focus</button>
       <input id="target">
     `;
-    const element = document.getElementById("trigger");
+    await vi.runAllTimersAsync();
+
     const target = document.getElementById("target");
     target.focus = vi.fn();
 
-    focusActions.focus(element, { target: "target" });
+    document.getElementById("trigger").click();
 
     expect(target.focus).toHaveBeenCalled();
   });
 
-  test("delays action with data-debounce", () => {
+  test("delays action with data-debounce", async () => {
+    attractive.activate();
+
     document.body.innerHTML = `
-      <button id="trigger" data-debounce="100">Focus</button>
+      <button id="trigger" @click="focus#target" @target="target" data-debounce="100">Focus</button>
       <input id="target">
     `;
-    const element = document.getElementById("trigger");
+    await vi.runAllTimersAsync();
+
     const target = document.getElementById("target");
     target.focus = vi.fn();
 
-    focusActions.focus(element, { target: "target" });
+    document.getElementById("trigger").click();
 
     expect(target.focus).not.toHaveBeenCalled();
 
@@ -40,40 +62,47 @@ describe("ActionBase - Global Debounce", () => {
     expect(target.focus).toHaveBeenCalled();
   });
 
-  test("debounces multiple rapid calls to same element", () => {
+  test("debounces multiple rapid calls to same element", async () => {
+    attractive.activate();
+
     document.body.innerHTML = `
-      <button id="trigger" data-debounce="100">Focus</button>
+      <button id="trigger" @click="focus#target" @target="target" data-debounce="100">Focus</button>
       <input id="target">
     `;
-    const element = document.getElementById("trigger");
+    await vi.runAllTimersAsync();
+
     const target = document.getElementById("target");
     target.focus = vi.fn();
 
-    focusActions.focus(element, { target: "target" });
-    focusActions.focus(element, { target: "target" });
-    focusActions.focus(element, { target: "target" });
+    const btn = document.getElementById("trigger");
+
+    btn.click();
+    btn.click();
+    btn.click();
 
     vi.advanceTimersByTime(100);
 
     expect(target.focus).toHaveBeenCalledTimes(1);
   });
 
-  test("different elements have independent debounce timers", () => {
+  test("different elements have independent debounce timers", async () => {
+    attractive.activate();
+
     document.body.innerHTML = `
-      <button id="a" data-debounce="100">A</button>
-      <button id="b" data-debounce="100">B</button>
+      <button id="a" @click="focus#target-a" @target="target-a" data-debounce="100">A</button>
+      <button id="b" @click="focus#target-b" @target="target-b" data-debounce="100">B</button>
       <input id="target-a">
       <input id="target-b">
     `;
-    const elementA = document.getElementById("a");
-    const elementB = document.getElementById("b");
+    await vi.runAllTimersAsync();
+
     const targetA = document.getElementById("target-a");
     const targetB = document.getElementById("target-b");
     targetA.focus = vi.fn();
     targetB.focus = vi.fn();
 
-    focusActions.focus(elementA, { target: "target-a" });
-    focusActions.focus(elementB, { target: "target-b" });
+    document.getElementById("a").click();
+    document.getElementById("b").click();
 
     expect(targetA.focus).not.toHaveBeenCalled();
     expect(targetB.focus).not.toHaveBeenCalled();
@@ -84,16 +113,19 @@ describe("ActionBase - Global Debounce", () => {
     expect(targetB.focus).toHaveBeenCalledTimes(1);
   });
 
-  test("supports legacy data-form-debounce attribute", () => {
+  test("supports legacy data-form-debounce attribute", async () => {
+    attractive.activate();
+
     document.body.innerHTML = `
-      <button id="trigger" data-form-debounce="100">Focus</button>
+      <button id="trigger" @click="focus#target" @target="target" data-form-debounce="100">Focus</button>
       <input id="target">
     `;
-    const element = document.getElementById("trigger");
+    await vi.runAllTimersAsync();
+
     const target = document.getElementById("target");
     target.focus = vi.fn();
 
-    focusActions.focus(element, { target: "target" });
+    document.getElementById("trigger").click();
 
     expect(target.focus).not.toHaveBeenCalled();
 
@@ -102,16 +134,19 @@ describe("ActionBase - Global Debounce", () => {
     expect(target.focus).toHaveBeenCalled();
   });
 
-  test("supports legacy data-request-debounce attribute", () => {
+  test("supports legacy data-request-debounce attribute", async () => {
+    attractive.activate();
+
     document.body.innerHTML = `
-      <button id="trigger" data-request-debounce="100">Focus</button>
+      <button id="trigger" @click="focus#target" @target="target" data-request-debounce="100">Focus</button>
       <input id="target">
     `;
-    const element = document.getElementById("trigger");
+    await vi.runAllTimersAsync();
+
     const target = document.getElementById("target");
     target.focus = vi.fn();
 
-    focusActions.focus(element, { target: "target" });
+    document.getElementById("trigger").click();
 
     expect(target.focus).not.toHaveBeenCalled();
 
@@ -120,16 +155,19 @@ describe("ActionBase - Global Debounce", () => {
     expect(target.focus).toHaveBeenCalled();
   });
 
-  test("data-debounce takes precedence over legacy attributes", () => {
+  test("data-debounce takes precedence over legacy attributes", async () => {
+    attractive.activate();
+
     document.body.innerHTML = `
-      <button id="trigger" data-debounce="50" data-form-debounce="200">Focus</button>
+      <button id="trigger" @click="focus#target" @target="target" data-debounce="50">Focus</button>
       <input id="target">
     `;
-    const element = document.getElementById("trigger");
+    await vi.runAllTimersAsync();
+
     const target = document.getElementById("target");
     target.focus = vi.fn();
 
-    focusActions.focus(element, { target: "target" });
+    document.getElementById("trigger").click();
 
     expect(target.focus).not.toHaveBeenCalled();
 

--- a/tests/actions/form.test.js
+++ b/tests/actions/form.test.js
@@ -1,7 +1,13 @@
 import { describe, test, expect, beforeEach, vi } from "vitest";
+
+import Attractive from "../../src/index.js";
 import formActions from "../../src/actions/form.js";
+import builtinActions from "../../src/actions/index.js";
+import { defaultDirectives } from "../../src/core/builtin_directives.js";
 
 describe("Form Actions", () => {
+  let attractive;
+
   beforeEach(() => {
     document.body.innerHTML = "";
     vi.clearAllTimers();
@@ -24,17 +30,31 @@ describe("Form Actions", () => {
       expect(form.requestSubmit).toHaveBeenCalled();
     });
 
-    test("submits form after delay", () => {
+    test("submits form after delay", async () => {
+      attractive = new Attractive();
+      attractive.registerActions((registry) => {
+        Object.entries(builtinActions).forEach(([name, action]) =>
+          registry.addAction(name, action)
+        );
+      });
+
+      attractive.registerDirectives((directives) => {
+        defaultDirectives(directives);
+      });
+
+      attractive.activate();
+
       document.body.innerHTML = `
-        <button id="trigger" data-form-debounce="100">Submit</button>
+        <button id="trigger" @click="submit#target" @target="target" data-form-debounce="100">Submit</button>
         <form id="target"></form>
       `;
-      const element = document.getElementById("trigger");
+      await vi.runAllTimersAsync();
+
       const form = document.getElementById("target");
 
       form.requestSubmit = vi.fn();
 
-      formActions.submit(element, { target: "target" });
+      document.getElementById("trigger").click();
 
       expect(form.requestSubmit).not.toHaveBeenCalled();
 

--- a/tests/addons/keyboard.test.js
+++ b/tests/addons/keyboard.test.js
@@ -30,8 +30,7 @@ describe("Keyboard addon", () => {
   });
 
   test("@keydown.enter fires only on Enter key", async () => {
-    attractive.extend(keyboard);
-    attractive.activate();
+    attractive.activate({ extendWith: [keyboard] });
 
     document.body.innerHTML = `
       <input id="input" @keydown.enter="addClass#enter" @target="target" />
@@ -51,8 +50,7 @@ describe("Keyboard addon", () => {
   });
 
   test("@keydown.enter does not fire on other keys", async () => {
-    attractive.extend(keyboard);
-    attractive.activate();
+    attractive.activate({ extendWith: [keyboard] });
 
     document.body.innerHTML = `
       <input id="input" @keydown.enter="addClass#enter" @target="target" />
@@ -72,8 +70,7 @@ describe("Keyboard addon", () => {
   });
 
   test("@keydown.escape fires only on Escape key", async () => {
-    attractive.extend(keyboard);
-    attractive.activate();
+    attractive.activate({ extendWith: [keyboard] });
 
     document.body.innerHTML = `
       <input id="input" @keydown.escape="addClass#escape" @target="target" />
@@ -93,8 +90,7 @@ describe("Keyboard addon", () => {
   });
 
   test("@keydown.ctrl.k fires on Ctrl+K combo", async () => {
-    attractive.extend(keyboard);
-    attractive.activate();
+    attractive.activate({ extendWith: [keyboard] });
 
     document.body.innerHTML = `
       <input id="input" @keydown.ctrl.k="addClass#combo" @target="target" />
@@ -114,8 +110,7 @@ describe("Keyboard addon", () => {
   });
 
   test("@keydown.ctrl.k does not fire on K without Ctrl", async () => {
-    attractive.extend(keyboard);
-    attractive.activate();
+    attractive.activate({ extendWith: [keyboard] });
 
     document.body.innerHTML = `
       <input id="input" @keydown.ctrl.k="addClass#combo" @target="target" />
@@ -135,8 +130,7 @@ describe("Keyboard addon", () => {
   });
 
   test("@keydown without modifiers still fires on any key", async () => {
-    attractive.extend(keyboard);
-    attractive.activate();
+    attractive.activate({ extendWith: [keyboard] });
 
     document.body.innerHTML = `
       <input id="input" @keydown="addClass#pressed" @target="target" />
@@ -156,8 +150,7 @@ describe("Keyboard addon", () => {
   });
 
   test("keyboard addon does not break @click.window", async () => {
-    attractive.extend(keyboard);
-    attractive.activate();
+    attractive.activate({ extendWith: [keyboard] });
 
     document.body.innerHTML = `
       <div id="outer" @click.window="addClass#clicked:whenOutside" @target="target">
@@ -177,8 +170,7 @@ describe("Keyboard addon", () => {
   });
 
   test("keyboard addon does not break regular click events", async () => {
-    attractive.extend(keyboard);
-    attractive.activate();
+    attractive.activate({ extendWith: [keyboard] });
 
     document.body.innerHTML = `
       <button id="btn" @click="addClass#clicked" @target="target">
@@ -196,8 +188,7 @@ describe("Keyboard addon", () => {
   });
 
   test("@hotkey.escape with value executes action", async () => {
-    attractive.extend(keyboard);
-    attractive.activate();
+    attractive.activate({ extendWith: [keyboard] });
 
     document.body.innerHTML = `
       <div @hotkey.escape="addClass#fired" @target="target"></div>
@@ -216,8 +207,7 @@ describe("Keyboard addon", () => {
   });
 
   test("@hotkey.ctrl+k with value fires on combo", async () => {
-    attractive.extend(keyboard);
-    attractive.activate();
+    attractive.activate({ extendWith: [keyboard] });
 
     document.body.innerHTML = `
       <div @hotkey.ctrl+k="addClass#fired" @target="target"></div>
@@ -236,8 +226,7 @@ describe("Keyboard addon", () => {
   });
 
   test("@hotkey.ctrl+k does not fire on K without Ctrl", async () => {
-    attractive.extend(keyboard);
-    attractive.activate();
+    attractive.activate({ extendWith: [keyboard] });
 
     document.body.innerHTML = `
       <div @hotkey.ctrl+k="addClass#fired" @target="target"></div>
@@ -256,8 +245,7 @@ describe("Keyboard addon", () => {
   });
 
   test("@hotkey.g.i sequence fires after g then i", async () => {
-    attractive.extend(keyboard);
-    attractive.activate();
+    attractive.activate({ extendWith: [keyboard] });
 
     document.body.innerHTML = `
       <div @hotkey.g.i="addClass#fired" @target="target"></div>
@@ -288,8 +276,7 @@ describe("Keyboard addon", () => {
   });
 
   test("bare @hotkey.escape triggers click on element", async () => {
-    attractive.extend(keyboard);
-    attractive.activate();
+    attractive.activate({ extendWith: [keyboard] });
 
     document.body.innerHTML = `
       <button @hotkey.escape id="btn">Close</button>
@@ -310,8 +297,7 @@ describe("Keyboard addon", () => {
   });
 
   test("@hotkey.g+i fires when both keys are held", async () => {
-    attractive.extend(keyboard);
-    attractive.activate();
+    attractive.activate({ extendWith: [keyboard] });
 
     document.body.innerHTML = `
       <div @hotkey.g+i="addClass#fired" @target="target"></div>
@@ -338,8 +324,7 @@ describe("Keyboard addon", () => {
   });
 
   test("@hotkey.g+i combo clears held keys after firing", async () => {
-    attractive.extend(keyboard);
-    attractive.activate();
+    attractive.activate({ extendWith: [keyboard] });
 
     document.body.innerHTML = `
       <div @hotkey.g+i="addClass#fired" @target="target"></div>
@@ -374,8 +359,7 @@ describe("Keyboard addon", () => {
   });
 
   test("@hotkey.g+i combo does not fire after keyup", async () => {
-    attractive.extend(keyboard);
-    attractive.activate();
+    attractive.activate({ extendWith: [keyboard] });
 
     document.body.innerHTML = `
       <div @hotkey.g+i="addClass#fired" @target="target"></div>
@@ -414,8 +398,7 @@ describe("Keyboard addon", () => {
   });
 
   test("@hotkey.g+i combo fires alongside same-key sequence", async () => {
-    attractive.extend(keyboard);
-    attractive.activate();
+    attractive.activate({ extendWith: [keyboard] });
 
     document.body.innerHTML = `
       <div @hotkey.g.i="addClass#seq" @target="seqTarget"></div>

--- a/tests/addons/reactive.test.js
+++ b/tests/addons/reactive.test.js
@@ -1,0 +1,328 @@
+import { describe, test, expect, beforeEach, vi } from "vitest";
+
+import Attractive from "../../src/index.js";
+import builtinActions from "../../src/actions/index.js";
+import { defaultDirectives } from "../../src/core/builtin_directives.js";
+import { reactive } from "../../src/addons/reactive/index.js";
+import { store } from "../../src/addons/reactive/store.js";
+
+let attractive;
+
+describe("Reactive addon", () => {
+  beforeEach(() => {
+    if (attractive) attractive.deactivate();
+    document.body.innerHTML = "";
+    vi.clearAllTimers();
+    vi.useFakeTimers();
+
+    attractive = new Attractive();
+
+    attractive.registerActions((registry) => {
+      Object.entries(builtinActions).forEach(([name, action]) =>
+        registry.addAction(name, action)
+      );
+    });
+
+    attractive.registerDirectives((directives) => {
+      defaultDirectives(directives);
+    });
+  });
+
+  describe("Store", () => {
+    test("set and get a value", () => {
+      store.set("name", { with: "Alice" });
+      expect(store.get("name")).toBe("Alice");
+    });
+
+    test("get returns undefined for unset key", () => {
+      expect(store.get("nonexistent")).toBeUndefined();
+    });
+  });
+
+  describe("@text binding", () => {
+    test("sets initial textContent from store", async () => {
+      store.set("text-greeting", { with: "Hello" });
+
+      attractive.activate({ extendWith: [reactive] });
+
+      document.body.innerHTML = `<p @text="text-greeting"></p>`;
+      await vi.runAllTimersAsync();
+
+      const p = document.querySelector("p");
+      expect(p.textContent).toBe("Hello");
+    });
+
+    test("updates textContent on store change", async () => {
+      attractive.activate({ extendWith: [reactive] });
+
+      document.body.innerHTML = `<p id="p" @text="text-update"></p>`;
+      await vi.runAllTimersAsync();
+
+      store.set("text-update", { with: "Hello, Alice!" });
+
+      expect(document.getElementById("p").textContent).toBe("Hello, Alice!");
+    });
+
+    test("shows empty string for unset key", () => {
+      attractive.activate({ extendWith: [reactive] });
+
+      document.body.innerHTML = `<p @text="text-unset"></p>`;
+
+      const p = document.querySelector("p");
+      expect(p.textContent).toBe("");
+    });
+
+    test("preserves element content when store has no value for the key", async () => {
+      attractive.activate({ extendWith: [reactive] });
+
+      document.body.innerHTML = `<span @text="text-preserve">Betty</span>`;
+      await vi.runAllTimersAsync();
+
+      const span = document.querySelector("span");
+      expect(span.textContent).toBe("Betty");
+    });
+
+    test("element content seeds the store when no value is set", async () => {
+      attractive.activate({ extendWith: [reactive] });
+
+      document.body.innerHTML = `<span @text="text-seed">Betty</span>`;
+      await vi.runAllTimersAsync();
+
+      expect(store.get("text-seed")).toBe("Betty");
+    });
+
+    test("seeded value updates when store is set", async () => {
+      attractive.activate({ extendWith: [reactive] });
+
+      document.body.innerHTML = `<span id="s" @text="text-seeded">Betty</span>`;
+      await vi.runAllTimersAsync();
+
+      store.set("text-seeded", { with: "Alice" });
+
+      expect(document.getElementById("s").textContent).toBe("Alice");
+    });
+
+    test("shows empty string for null value", () => {
+      store.set("text-null", { with: null });
+
+      attractive.activate({ extendWith: [reactive] });
+
+      document.body.innerHTML = `<p @text="text-null"></p>`;
+
+      const p = document.querySelector("p");
+      expect(p.textContent).toBe("");
+    });
+
+    test("shows empty string for undefined value", () => {
+      store.set("text-undefined", { with: undefined });
+
+      attractive.activate({ extendWith: [reactive] });
+
+      document.body.innerHTML = `<p @text="text-undefined"></p>`;
+
+      const p = document.querySelector("p");
+      expect(p.textContent).toBe("");
+    });
+
+    test("multiple elements bound to same key all update", async () => {
+      attractive.activate({ extendWith: [reactive] });
+
+      document.body.innerHTML = `
+        <p id="a" @text="text-multi"></p>
+        <p id="b" @text="text-multi"></p>
+      `;
+      await vi.runAllTimersAsync();
+
+      store.set("text-multi", { with: "Bob" });
+
+      expect(document.getElementById("a").textContent).toBe("Bob");
+      expect(document.getElementById("b").textContent).toBe("Bob");
+    });
+
+    test("removing @text attribute unbinds listener", async () => {
+      store.set("text-removal", { with: "hello" });
+
+      attractive.activate({ extendWith: [reactive] });
+
+      document.body.innerHTML = `<p id="p" @text="text-removal"></p>`;
+      await Promise.resolve();
+
+      const p = document.getElementById("p");
+      expect(p.textContent).toBe("hello");
+
+      p.removeAttribute("@text");
+      await Promise.resolve();
+
+      store.set("text-removal", { with: "world" });
+
+      expect(p.textContent).toBe("hello");
+    });
+
+    test("works inside template clone", async () => {
+      attractive.activate({ extendWith: [reactive] });
+
+      const template = document.createElement("template");
+      template.innerHTML = `<p @text="text-template"></p>`;
+
+      const clone = template.content.cloneNode(true);
+      document.body.appendChild(clone);
+      await vi.runAllTimersAsync();
+
+      store.set("text-template", { with: "from template" });
+
+      expect(document.querySelector("p").textContent).toBe("from template");
+    });
+  });
+
+  describe("setStore action", () => {
+    test("on input writes element value to store", async () => {
+      store.set("action-input", { with: "" });
+
+      attractive.activate({ extendWith: [reactive] });
+
+      document.body.innerHTML = `
+        <input id="input" @input="setStore#action-input" />
+      `;
+      await vi.runAllTimersAsync();
+
+      const input = document.getElementById("input");
+      input.value = "hi";
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      await vi.runAllTimersAsync();
+
+      expect(store.get("action-input")).toBe("hi");
+    });
+
+    test("debounce delays store update", async () => {
+      attractive.activate({ extendWith: [reactive] });
+
+      document.body.innerHTML = `
+        <input id="input" @input="setStore#action-delay" data-debounce="200" />
+      `;
+      await Promise.resolve();
+
+      const input = document.getElementById("input");
+      input.value = "hello";
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+
+      expect(store.get("action-delay")).toBeUndefined();
+      expect(vi.getTimerCount()).toBe(1);
+
+      vi.advanceTimersByTime(200);
+
+      expect(store.get("action-delay")).toBe("hello");
+    });
+
+    test("on non-input element sets true", async () => {
+      attractive.activate({ extendWith: [reactive] });
+
+      document.body.innerHTML = `
+        <button id="btn" @click="setStore#action-active"></button>
+      `;
+      await vi.runAllTimersAsync();
+
+      document.getElementById("btn").click();
+      await vi.runAllTimersAsync();
+
+      expect(store.get("action-active")).toBe(true);
+    });
+  });
+
+  describe("whenTrue / whenFalse", () => {
+    test("whenTrue fires action on truthy store value", async () => {
+      attractive.activate({ extendWith: [reactive] });
+
+      document.body.innerHTML = `
+        <div id="el" data-store="st" @action="addClass#fired:whenTrue"></div>
+      `;
+      await vi.runAllTimersAsync();
+
+      store.set("st", { with: true });
+      await vi.runAllTimersAsync();
+
+      expect(document.getElementById("el").classList.contains("fired")).toBe(
+        true
+      );
+    });
+
+    test("whenTrue does not fire on falsy store value", async () => {
+      store.set("st", { with: false });
+
+      attractive.activate({ extendWith: [reactive] });
+
+      document.body.innerHTML = `
+        <div id="el" data-store="st" @action="addClass#fired:whenTrue"></div>
+      `;
+      await vi.runAllTimersAsync();
+
+      store.set("st", { with: true });
+      await vi.runAllTimersAsync();
+
+      expect(document.getElementById("el").classList.contains("fired")).toBe(
+        true
+      );
+    });
+
+    test("whenFalse fires action on falsy store value", async () => {
+      store.set("st", { with: true });
+
+      attractive.activate({ extendWith: [reactive] });
+
+      document.body.innerHTML = `
+        <div id="el" data-store="st" @action="removeAttribute#fired:whenFalse"></div>
+      `;
+      await vi.runAllTimersAsync();
+
+      store.set("st", { with: false });
+      await vi.runAllTimersAsync();
+
+      expect(document.getElementById("el").hasAttribute("fired")).toBe(false);
+    });
+
+    test("whenTrue and whenFalse pair for set/remove", async () => {
+      attractive.activate({ extendWith: [reactive] });
+
+      document.body.innerHTML = `
+        <div id="el" data-store="st" @action="addAttribute#fired:whenTrue removeAttribute#fired:whenFalse"></div>
+      `;
+      await vi.runAllTimersAsync();
+
+      store.set("st", { with: true });
+      await vi.runAllTimersAsync();
+      expect(document.getElementById("el").hasAttribute("fired")).toBe(true);
+
+      store.set("st", { with: false });
+      await vi.runAllTimersAsync();
+      expect(document.getElementById("el").hasAttribute("fired")).toBe(false);
+    });
+
+    test("does not fire when store.set is never called", async () => {
+      attractive.activate({ extendWith: [reactive] });
+
+      document.body.innerHTML = `
+        <div id="el" data-store="st" @action="addClass#fired:whenTrue"></div>
+      `;
+      await vi.runAllTimersAsync();
+
+      expect(document.getElementById("el").classList.contains("fired")).toBe(
+        false
+      );
+    });
+
+    test("works with element in initial HTML", async () => {
+      document.body.innerHTML = `
+        <div id="el" data-store="st" @action="addClass#fired:whenTrue"></div>
+      `;
+
+      attractive.activate({ extendWith: [reactive] });
+      await vi.runAllTimersAsync();
+
+      store.set("st", { with: true });
+      await vi.runAllTimersAsync();
+
+      expect(document.getElementById("el").classList.contains("fired")).toBe(
+        true
+      );
+    });
+  });
+});

--- a/tests/integration/extend.test.js
+++ b/tests/integration/extend.test.js
@@ -6,7 +6,7 @@ import { defaultDirectives } from "../../src/core/builtin_directives.js";
 globalThis.Node = globalThis.Node || { ELEMENT_NODE: 1 };
 
 describe("Extend", () => {
-  test("accepts an array of extensions", async () => {
+  test("accepts an array via extendWith", async () => {
     const attractive = new Core();
 
     attractive.addAction("addClass", addClass);
@@ -17,8 +17,7 @@ describe("Extend", () => {
     const first = vi.fn();
     const second = vi.fn();
 
-    attractive.extend([first, second]);
-    attractive.activate();
+    attractive.activate({ extendWith: [first, second] });
 
     expect(first).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/tests/integration/lifecycle.test.js
+++ b/tests/integration/lifecycle.test.js
@@ -3,11 +3,11 @@ import Attractive from "../../src/index.js";
 import builtinActions from "../../src/actions/index.js";
 import { defaultDirectives } from "../../src/core/builtin_directives.js";
 
-globalThis.Node = globalThis.Node || { ELEMENT_NODE: 1 };
-
 let attractive;
 
 beforeEach(() => {
+  if (attractive) attractive.deactivate();
+
   document.body.innerHTML = "";
   vi.clearAllTimers();
   vi.useFakeTimers();
@@ -130,4 +130,23 @@ test("active returns true after restart", () => {
   attractive.restart();
 
   expect(attractive.active).toBe(true);
+});
+
+test("removing @action attribute cleans up action", async () => {
+  attractive.activate();
+
+  document.body.innerHTML = `<button id="btn" @action="toggleClass#toggled" @target="target"><span id="target">Target</span></button>`;
+  await vi.runAllTimersAsync();
+
+  const btn = document.getElementById("btn");
+  const target = document.getElementById("target");
+
+  btn.click();
+  expect(target.classList.contains("toggled")).toBe(true);
+
+  btn.removeAttribute("@action");
+  await vi.runAllTimersAsync();
+
+  btn.click();
+  expect(target.classList.contains("toggled")).toBe(true);
 });


### PR DESCRIPTION
Allows a `@text` directive (reactive?) that is "hydrated" using a "store" (name; TBD).

Basic example:
```
<input @input="setStore#name" />
<span @text="name"></span>
```

This also adds a "global" debounce option (not limited to certain actions). 